### PR TITLE
Add command center brief repo trace

### DIFF
--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
@@ -173,35 +173,141 @@ function renderEvidenceCard(item) {
 
 function renderBriefShell(escalations) {
   const top = [...escalations].sort((a, b) => severityRank(b.severity) - severityRank(a.severity)).slice(0, 4);
+  const blockers = [
+    ...new Set([
+      ...state.data.briefDefaults.blockers,
+      ...escalations.filter((item) => item.status === 'blocked').map((item) => item.title)
+    ])
+  ];
   document.getElementById('brief-content').innerHTML = `
     <div class="metric-row">
       ${metric('Critical', escalations.filter((item) => item.severity === 'critical').length)}
       ${metric('Open', escalations.filter((item) => item.status === 'open').length)}
       ${metric('Blocked', escalations.filter((item) => item.status === 'blocked').length)}
+      ${metric('Decisions', state.data.briefDefaults.unresolvedDecisions.length)}
     </div>
-    <div class="placeholder compact">
-      <strong>Executive brief data ready</strong>
-      <p>Top items are already derived from the queue. Heatmap, blockers, and decision summary land in the next app batch.</p>
-      <ul>${top.map((item) => `<li>${escapeHtml(item.title)}</li>`).join('')}</ul>
+    <div class="brief-layout">
+      <section class="brief-card wide">
+        <h3>Top executive risks</h3>
+        <div class="stack">${top.map(renderTopRisk).join('')}</div>
+      </section>
+      <section class="brief-card">
+        <h3>Severity heatmap</h3>
+        ${renderHeatmap(escalations)}
+      </section>
+      <section class="brief-card">
+        <h3>Blockers</h3>
+        <ul>${blockers.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
+      </section>
+      <section class="brief-card">
+        <h3>Unresolved decisions</h3>
+        <ul>${state.data.briefDefaults.unresolvedDecisions.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
+      </section>
+      <section class="brief-card">
+        <h3>Recommended next actions</h3>
+        <ul>${state.data.briefDefaults.recommendedActions.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
+      </section>
     </div>
   `;
 }
 
 function renderRepoShell() {
+  const artifacts = state.data.issueArtifacts;
   document.getElementById('repo-content').innerHTML = `
-    <div class="placeholder compact">
-      <strong>Fabricated repo data ready</strong>
-      <p>${state.local.showSimulatedActivity ? 'Simulated commit and PR activity is enabled.' : 'Simulated commit and PR activity is hidden.'}</p>
+    <div class="notice">
+      <strong>Fabricated local repo:</strong>
+      <span>This view teaches issue breakdown. It does not call GitHub or create live issues, commits, or pull requests.</span>
+    </div>
+    <div class="metric-row">
+      ${metric('Issues', artifacts.length)}
+      ${metric('Milestones', unique(artifacts.map((item) => item.milestone)).length)}
+      ${metric('Simulated activity', state.local.showSimulatedActivity ? 'Shown' : 'Hidden')}
+    </div>
+    <div class="repo-grid">
+      ${artifacts.map(renderIssueArtifact).join('')}
     </div>
   `;
 }
 
 function renderTraceShell() {
   document.getElementById('trace-content').innerHTML = `
-    <div class="placeholder compact">
-      <strong>Build Trace data ready</strong>
-      <p>${state.data.buildTrace.length} artifact steps loaded from local seed data.</p>
-    </div>
+    <ol class="trace-list">
+      ${state.data.buildTrace.map((item) => `
+        <li>
+          <span>${escapeHtml(item.id)}</span>
+          <h3>${escapeHtml(item.step)}</h3>
+          <p>${escapeHtml(item.summary)}</p>
+          <code>${escapeHtml(item.source)}</code>
+        </li>
+      `).join('')}
+    </ol>
+  `;
+}
+
+function renderTopRisk(item) {
+  return `
+    <article class="risk-line">
+      <div>
+        <strong>${escapeHtml(item.title)}</strong>
+        <span>${escapeHtml(item.division)} · owner ${escapeHtml(item.owner)} · decision ${escapeHtml(item.decisionOwner)}</span>
+      </div>
+      <span class="severity ${escapeAttr(item.severity)}">${escapeHtml(item.severity)}</span>
+      <p>${escapeHtml(item.businessImpact)}</p>
+      <em>${escapeHtml(item.nextAction)}</em>
+    </article>
+  `;
+}
+
+function renderHeatmap(escalations) {
+  const divisions = unique(escalations.map((item) => item.division));
+  const severities = ['critical', 'high', 'medium', 'low'];
+  return `
+    <table class="heatmap">
+      <thead>
+        <tr>
+          <th>Division</th>
+          ${severities.map((item) => `<th>${escapeHtml(item)}</th>`).join('')}
+        </tr>
+      </thead>
+      <tbody>
+        ${divisions.map((division) => `
+          <tr>
+            <td>${escapeHtml(division)}</td>
+            ${severities.map((severity) => {
+              const count = escalations.filter((item) => item.division === division && item.severity === severity).length;
+              return `<td class="heat ${count ? severity : ''}">${count}</td>`;
+            }).join('')}
+          </tr>
+        `).join('')}
+      </tbody>
+    </table>
+  `;
+}
+
+function renderIssueArtifact(item) {
+  return `
+    <article class="issue-card">
+      <header>
+        <span>${escapeHtml(item.id)}</span>
+        <strong>${escapeHtml(item.title)}</strong>
+      </header>
+      <p>${escapeHtml(item.implementationNotes)}</p>
+      <div class="tag-row">${item.labels.map((label) => `<span class="tag">${escapeHtml(label)}</span>`).join('')}</div>
+      <dl>
+        <dt>Milestone</dt>
+        <dd>${escapeHtml(item.milestone)}</dd>
+        <dt>Acceptance</dt>
+        <dd><ul>${item.acceptanceCriteria.map((criterion) => `<li>${escapeHtml(criterion)}</li>`).join('')}</ul></dd>
+        <dt>Evidence needed</dt>
+        <dd>${item.evidenceNeeded.map(escapeHtml).join(', ')}</dd>
+      </dl>
+      ${state.local.showSimulatedActivity ? `
+        <div class="simulated">
+          <strong>${escapeHtml(item.simulatedPr)}</strong>
+          <ul>${item.simulatedCommits.map((commit) => `<li>${escapeHtml(commit)}</li>`).join('')}</ul>
+        </div>
+      ` : ''}
+    </article>
   `;
 }
 

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/styles.css
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/styles.css
@@ -456,6 +456,257 @@ td em {
   white-space: nowrap;
 }
 
+.brief-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
+  gap: 1rem;
+}
+
+.brief-card,
+.issue-card,
+.notice,
+.trace-list li,
+.risk-line {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.brief-card {
+  padding: 1rem;
+}
+
+.brief-card.wide {
+  grid-row: span 2;
+}
+
+.brief-card h3,
+.issue-card h3,
+.risk-line h3 {
+  margin-top: 0;
+}
+
+.brief-card ul,
+.issue-card ul,
+.simulated ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.stack {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.risk-line {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.55rem 0.8rem;
+  padding: 0.85rem;
+}
+
+.risk-line strong,
+.risk-line span,
+.risk-line p,
+.risk-line em {
+  display: block;
+}
+
+.risk-line span,
+.risk-line p {
+  color: var(--muted);
+}
+
+.risk-line p {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.risk-line em {
+  grid-column: 1 / -1;
+  color: var(--cyan);
+  font-style: normal;
+}
+
+.heatmap {
+  min-width: 0;
+  font-size: 0.86rem;
+}
+
+.heatmap th,
+.heatmap td {
+  padding: 0.55rem;
+}
+
+.heatmap .heat {
+  text-align: center;
+  font-weight: 900;
+}
+
+.heat.critical {
+  color: var(--red);
+  background: rgba(251, 113, 133, 0.12);
+}
+
+.heat.high {
+  color: var(--amber);
+  background: rgba(251, 191, 36, 0.12);
+}
+
+.heat.medium {
+  color: var(--blue);
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.notice {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  padding: 0.9rem 1rem;
+  color: var(--muted);
+}
+
+.notice strong {
+  color: var(--cyan);
+}
+
+.repo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.issue-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.issue-card header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.issue-card header span {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+}
+
+.issue-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.issue-card dl {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.issue-card dt {
+  color: var(--faint);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.issue-card dd {
+  margin: 0;
+  color: var(--muted);
+}
+
+.simulated {
+  padding: 0.75rem;
+  border: 1px solid rgba(94, 234, 212, 0.28);
+  border-radius: 8px;
+  background: rgba(94, 234, 212, 0.06);
+}
+
+.simulated strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--cyan);
+}
+
+.trace-list {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: trace;
+}
+
+.trace-list li {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 0.9rem;
+  padding: 1rem;
+}
+
+.trace-list li::before {
+  counter-increment: trace;
+  content: counter(trace);
+  display: grid;
+  place-items: center;
+  grid-row: span 3;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  color: #061018;
+  background: var(--cyan);
+  font-weight: 900;
+}
+
+.trace-list span {
+  color: var(--faint);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+}
+
+.trace-list h3,
+.trace-list p {
+  margin: 0;
+}
+
+.trace-list p {
+  color: var(--muted);
+}
+
+.trace-list code {
+  width: fit-content;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  padding: 0.28rem 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--cyan);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+@media (max-width: 980px) {
+  .brief-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .brief-card.wide {
+    grid-row: auto;
+  }
+}
+
 @media (max-width: 760px) {
   .app-header {
     display: block;


### PR DESCRIPTION
## Summary
- Adds the executive brief with top risks, heatmap, blockers, unresolved decisions, and recommended actions.
- Adds the fabricated local repo view with issue artifacts and simulated PR activity toggle.
- Adds the Build Trace timeline with repo-relative source references.

## Verification
- node --check event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
- python3 -m json.tool event-specific/personal-ai-agents-live-2026-07-21/demo/app/data/app-seed.json
- local Chromium smoke test for executive brief, repo simulated activity toggle, and Build Trace
- sensitive path and source filename scan over demo/app

Closes #38
Closes #39
Closes #40
