### PR TITLE
Fix Personal AI Agents LIVE file demo data loading

### DIFF
--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
@@ -47,15 +47,32 @@ function setActiveTab(tabName) {
 
 async function loadSeedData() {
   try {
-    const response = await fetch('data/app-seed.json', { cache: 'no-store' });
-    if (!response.ok) throw new Error(`Seed data request failed: ${response.status}`);
-    state.data = await response.json();
+    state.data = location.protocol === 'file:' ? embeddedSeedData() : await fetchSeedData();
     renderAll();
     setStatus('Seed data loaded', 'ready');
   } catch (error) {
-    renderLoadError(error);
-    setStatus('Data fallback', 'error');
+    try {
+      state.data = embeddedSeedData();
+      renderAll();
+      setStatus('Seed data loaded', 'ready');
+    } catch {
+      renderLoadError(error);
+      setStatus('Data unavailable', 'error');
+    }
   }
+}
+
+async function fetchSeedData() {
+  const response = await fetch('data/app-seed.json', { cache: 'no-store' });
+  if (!response.ok) throw new Error(`Seed data request failed: ${response.status}`);
+  return response.json();
+}
+
+function embeddedSeedData() {
+  if (!window.ECORP_APP_SEED) throw new Error('Embedded seed data was not available.');
+  return typeof structuredClone === 'function'
+    ? structuredClone(window.ECORP_APP_SEED)
+    : JSON.parse(JSON.stringify(window.ECORP_APP_SEED));
 }
 
 function renderAll() {
@@ -500,7 +517,7 @@ function renderLoadError(error) {
   document.querySelectorAll('.placeholder').forEach((el) => {
     el.innerHTML = `
       <strong>App shell loaded</strong>
-      <p>Seed data was not available. Serve this directory locally to load <code>data/app-seed.json</code>.</p>
+      <p>Seed data was not available. Reload the checked-in demo folder or serve this directory locally.</p>
       <p>${escapeHtml(error.message)}</p>
     `;
   });

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/data/app-seed.js
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/data/app-seed.js
@@ -1,0 +1,1140 @@
+// Generated from app-seed.json so the demo can run directly from file://.
+window.ECORP_APP_SEED = {
+  "meta": {
+    "appName": "E Corp Cyber Escalation Command Center",
+    "status": "fictional workshop material",
+    "safetyNotice": "Local-only simulated command center. No live accounts, external services, real incident data, credentials, or operational cyber instructions.",
+    "scenario": "Post-5/9 recovery pressure across E Corp divisions.",
+    "sourceRoot": "event-specific/personal-ai-agents-live-2026-07-21"
+  },
+  "people": [
+    "Angela Moss",
+    "Phillip Price",
+    "Tyrell Wellick",
+    "Susan Jacobs",
+    "Scott Knowles",
+    "Janet Robinson",
+    "Bobbi",
+    "Gideon Goddard",
+    "Dominique DiPierro",
+    "Samar Swailem"
+  ],
+  "escalations": [
+    {
+      "id": "ESC-001",
+      "sourceSignalId": "SIG-001",
+      "title": "Identity recovery backlog blocks Bank of E account restoration",
+      "category": "issue",
+      "division": "Bank of E",
+      "system": "Identity Recovery Portal",
+      "severity": "critical",
+      "status": "open",
+      "owner": "Tyrell Wellick",
+      "decisionOwner": "Angela Moss",
+      "slaRisk": "at-risk",
+      "confidence": "high",
+      "businessImpact": "Customer access restoration is delayed and support volume remains elevated.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-03",
+        "EV-EMAIL-19",
+        "EV-CHAT-11",
+        "EV-SIGNAL-001"
+      ],
+      "nextAction": "Separate lockout volume from suspected abuse and assign the decision owner."
+    },
+    {
+      "id": "ESC-002",
+      "sourceSignalId": "SIG-002",
+      "title": "E Coin fraud signal quality is inconsistent",
+      "category": "risk",
+      "division": "E Coin",
+      "system": "E Coin Ledger Monitoring",
+      "severity": "high",
+      "status": "triage",
+      "owner": "Samar Swailem",
+      "decisionOwner": "Angela Moss",
+      "slaRisk": "watch",
+      "confidence": "medium",
+      "businessImpact": "False positives may slow customer recovery while true fraud remains difficult to prioritize.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-10",
+        "EV-CHAT-03",
+        "EV-SIGNAL-002"
+      ],
+      "nextAction": "Add evidence confidence and finance review before executive escalation."
+    },
+    {
+      "id": "ESC-003",
+      "sourceSignalId": "SIG-003",
+      "title": "External agency asks for decision timeline",
+      "category": "threat",
+      "division": "Legal and Risk",
+      "system": "Legal Evidence Register",
+      "severity": "high",
+      "status": "open",
+      "owner": "Susan Jacobs",
+      "decisionOwner": "Phillip Price",
+      "slaRisk": "at-risk",
+      "confidence": "high",
+      "businessImpact": "Leadership needs a defensible timeline of evidence and decisions.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-08",
+        "EV-EMAIL-24",
+        "EV-CHAT-06",
+        "EV-SIGNAL-003"
+      ],
+      "nextAction": "Link every executive recommendation to reviewed source evidence."
+    },
+    {
+      "id": "ESC-004",
+      "sourceSignalId": "SIG-004",
+      "title": "Healthcare portal readiness is blocked by access review",
+      "category": "issue",
+      "division": "E Healthcare",
+      "system": "E Healthcare Patient Portal",
+      "severity": "critical",
+      "status": "open",
+      "owner": "Scott Knowles",
+      "decisionOwner": "Janet Robinson",
+      "slaRisk": "breached",
+      "confidence": "medium",
+      "businessImpact": "Patient-facing operations may be delayed unless access review is resolved.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-15",
+        "EV-CHAT-04",
+        "EV-SIGNAL-004"
+      ],
+      "nextAction": "Escalate the owner and identify the residual-risk decision needed."
+    },
+    {
+      "id": "ESC-005",
+      "sourceSignalId": "SIG-005",
+      "title": "Employee payroll phishing confusion",
+      "category": "risk",
+      "division": "HR",
+      "system": "Employee Communications Queue",
+      "severity": "medium",
+      "status": "triage",
+      "owner": "Bobbi",
+      "decisionOwner": "Susan Jacobs",
+      "slaRisk": "watch",
+      "confidence": "medium",
+      "businessImpact": "Employees may trust incorrect payroll or benefits messages during recovery.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-06",
+        "EV-EMAIL-14",
+        "EV-CHAT-02",
+        "EV-SIGNAL-005"
+      ],
+      "nextAction": "Draft HR and legal reviewed employee guidance outside the prototype."
+    },
+    {
+      "id": "ESC-006",
+      "sourceSignalId": "SIG-006",
+      "title": "Recovery site building access queue delays operations",
+      "category": "issue",
+      "division": "E Corp Recovery Program",
+      "system": "Recovery Site Access",
+      "severity": "high",
+      "status": "open",
+      "owner": "Scott Knowles",
+      "decisionOwner": "Janet Robinson",
+      "slaRisk": "at-risk",
+      "confidence": "high",
+      "businessImpact": "Recovery teams cannot rotate staff efficiently across sites.",
+      "linkedEvidenceIds": [
+        "EV-CHAT-04",
+        "EV-SIGNAL-006"
+      ],
+      "nextAction": "Assign operations owner and track patient or banking impact."
+    },
+    {
+      "id": "ESC-007",
+      "sourceSignalId": "SIG-007",
+      "title": "Shipping delays are being over-classified as cyber incidents",
+      "category": "risk",
+      "division": "E Shipping",
+      "system": "E Shipping Routing Dashboard",
+      "severity": "medium",
+      "status": "monitoring",
+      "owner": "Angela Moss",
+      "decisionOwner": "Scott Knowles",
+      "slaRisk": "on-track",
+      "confidence": "high",
+      "businessImpact": "Incident queues are noisy and executives may misread operational delays as active threats.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-15",
+        "EV-CHAT-13",
+        "EV-SIGNAL-007"
+      ],
+      "nextAction": "Separate recovery issue category from threat category."
+    },
+    {
+      "id": "ESC-008",
+      "sourceSignalId": "SIG-008",
+      "title": "Unverified adversarial chatter references recovery systems",
+      "category": "threat",
+      "division": "Technology Operations",
+      "system": "Executive Briefing Workflow",
+      "severity": "high",
+      "status": "monitoring",
+      "owner": "Tyrell Wellick",
+      "decisionOwner": "Susan Jacobs",
+      "slaRisk": "watch",
+      "confidence": "low",
+      "businessImpact": "Leadership needs awareness without treating unverified chatter as confirmed activity.",
+      "linkedEvidenceIds": [
+        "EV-CHAT-14",
+        "EV-SIGNAL-008"
+      ],
+      "nextAction": "Keep as low-confidence threat signal pending corroboration."
+    },
+    {
+      "id": "ESC-009",
+      "sourceSignalId": "SIG-009",
+      "title": "Third-party assurance note is incomplete",
+      "category": "issue",
+      "division": "Technology Operations",
+      "system": "Legal Evidence Register",
+      "severity": "medium",
+      "status": "blocked",
+      "owner": "Gideon Goddard",
+      "decisionOwner": "Tyrell Wellick",
+      "slaRisk": "watch",
+      "confidence": "high",
+      "businessImpact": "Executive brief cannot claim reviewed readiness for systems not inspected.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-05",
+        "EV-CHAT-05",
+        "EV-SIGNAL-009"
+      ],
+      "nextAction": "Mark evidence pending and avoid overstatement."
+    },
+    {
+      "id": "ESC-010",
+      "sourceSignalId": "SIG-010",
+      "title": "Executive summaries lack owner and decision owner separation",
+      "category": "risk",
+      "division": "Executive Operations",
+      "system": "Executive Briefing Workflow",
+      "severity": "high",
+      "status": "open",
+      "owner": "Janet Robinson",
+      "decisionOwner": "Phillip Price",
+      "slaRisk": "at-risk",
+      "confidence": "high",
+      "businessImpact": "Escalations stall because action ownership and decision authority are blended.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-07",
+        "EV-EMAIL-18",
+        "EV-CHAT-09",
+        "EV-SIGNAL-010"
+      ],
+      "nextAction": "Keep action owner and decision owner as separate fields."
+    },
+    {
+      "id": "ESC-011",
+      "sourceSignalId": "SIG-011",
+      "title": "Support console recovery creates inconsistent customer guidance",
+      "category": "issue",
+      "division": "E Phone",
+      "system": "E Phone Support Console",
+      "severity": "medium",
+      "status": "triage",
+      "owner": "Lloyd Chong",
+      "decisionOwner": "Bobbi",
+      "slaRisk": "watch",
+      "confidence": "medium",
+      "businessImpact": "Support representatives may give inconsistent recovery instructions.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-20",
+        "EV-SIGNAL-011"
+      ],
+      "nextAction": "Flag as communications and support enablement issue."
+    },
+    {
+      "id": "ESC-012",
+      "sourceSignalId": "SIG-012",
+      "title": "Evidence review status is not visible in triage meetings",
+      "category": "risk",
+      "division": "Legal and Risk",
+      "system": "Legal Evidence Register",
+      "severity": "high",
+      "status": "open",
+      "owner": "Susan Jacobs",
+      "decisionOwner": "Angela Moss",
+      "slaRisk": "at-risk",
+      "confidence": "high",
+      "businessImpact": "Unreviewed evidence may be presented as settled fact.",
+      "linkedEvidenceIds": [
+        "EV-EMAIL-04",
+        "EV-MEMO-04",
+        "EV-SIGNAL-012"
+      ],
+      "nextAction": "Show reviewed, unreviewed, disputed, and pending evidence states in the app."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "EV-EMAIL-03",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Tyrell Wellick",
+        "Scott Knowles"
+      ],
+      "division": "Bank of E",
+      "escalationIds": [
+        "ESC-001"
+      ],
+      "summary": "Identity backlog is blocking Bank of E and E Phone support recovery.",
+      "excerpt": "Distinguish user lockout volume from suspected abuse patterns.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-03"
+    },
+    {
+      "id": "EV-EMAIL-04",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Susan Jacobs",
+        "Angela Moss"
+      ],
+      "division": "Legal and Risk",
+      "escalationIds": [
+        "ESC-012"
+      ],
+      "summary": "Executive summaries need evidence source status.",
+      "excerpt": "Every cited item needs source status: reviewed, unreviewed, disputed, or external request.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-04"
+    },
+    {
+      "id": "EV-EMAIL-05",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Gideon Goddard",
+        "Tyrell Wellick"
+      ],
+      "division": "Technology Operations",
+      "escalationIds": [
+        "ESC-009"
+      ],
+      "summary": "Third-party readiness cannot overstate systems not inspected.",
+      "excerpt": "Use evidence pending where the record is incomplete.",
+      "status": "pending",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-05"
+    },
+    {
+      "id": "EV-EMAIL-06",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Bobbi",
+        "Janet Robinson"
+      ],
+      "division": "HR",
+      "escalationIds": [
+        "ESC-005"
+      ],
+      "summary": "HR is receiving payroll, benefits, and building-access questions.",
+      "excerpt": "If security needs employees to ignore certain messages, HR needs approved wording.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/emails.md#email-06"
+    },
+    {
+      "id": "EV-EMAIL-07",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Scott Knowles",
+        "Angela Moss"
+      ],
+      "division": "Executive Operations",
+      "escalationIds": [
+        "ESC-010"
+      ],
+      "summary": "Action owner and decision owner need separate fields.",
+      "excerpt": "Several escalations list Technology as owner, but the blocker is business acceptance.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-07"
+    },
+    {
+      "id": "EV-EMAIL-08",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Dominique DiPierro",
+        "Susan Jacobs"
+      ],
+      "division": "Legal and Risk",
+      "escalationIds": [
+        "ESC-003"
+      ],
+      "summary": "External investigators will request a timeline of decisions and notifications.",
+      "excerpt": "Preserve the source chain for any escalation that changes status.",
+      "status": "external request",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-08"
+    },
+    {
+      "id": "EV-EMAIL-10",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Samar Swailem",
+        "Tyrell Wellick"
+      ],
+      "division": "E Coin",
+      "escalationIds": [
+        "ESC-002"
+      ],
+      "summary": "E Coin fraud spikes include recovery retry noise.",
+      "excerpt": "Some look like customer retry behavior after failed recovery notices.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/emails.md#email-10"
+    },
+    {
+      "id": "EV-EMAIL-14",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Susan Jacobs",
+        "Bobbi"
+      ],
+      "division": "HR",
+      "escalationIds": [
+        "ESC-005"
+      ],
+      "summary": "Employee-facing messages need legal and HR review.",
+      "excerpt": "The app can draft next actions, but it must not publish wording.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-14"
+    },
+    {
+      "id": "EV-EMAIL-15",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Scott Knowles",
+        "Janet Robinson"
+      ],
+      "division": "E Healthcare",
+      "escalationIds": [
+        "ESC-004",
+        "ESC-007"
+      ],
+      "summary": "Shipping and healthcare need separate severity language.",
+      "excerpt": "A delayed shipment and patient portal concern should not use the same business-impact wording.",
+      "status": "reviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/emails.md#email-15"
+    },
+    {
+      "id": "EV-EMAIL-18",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Phillip Price",
+        "Angela Moss"
+      ],
+      "division": "Executive Operations",
+      "escalationIds": [
+        "ESC-010"
+      ],
+      "summary": "Executive end state is a readable brief, accountable owner, and trace.",
+      "excerpt": "Show a brief I can read, an owner I can hold accountable, and a trace showing how the recommendation was created.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-18"
+    },
+    {
+      "id": "EV-EMAIL-19",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Sunil Markesh",
+        "Angela Moss"
+      ],
+      "division": "Bank of E",
+      "escalationIds": [
+        "ESC-001"
+      ],
+      "summary": "Branch teams report the same recovery issue under different names.",
+      "excerpt": "Group duplicate symptoms before executives see them.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/emails.md#email-19"
+    },
+    {
+      "id": "EV-EMAIL-20",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Lloyd Chong",
+        "Gideon Goddard"
+      ],
+      "division": "E Phone",
+      "escalationIds": [
+        "ESC-011"
+      ],
+      "summary": "Support tickets use vague recovery labels.",
+      "excerpt": "The app needs a simple way to show uncertainty without hiding the signal.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/emails.md#email-20"
+    },
+    {
+      "id": "EV-EMAIL-24",
+      "type": "email",
+      "date": "2026-07-21",
+      "participants": [
+        "Dominique DiPierro",
+        "Angela Moss"
+      ],
+      "division": "Legal and Risk",
+      "escalationIds": [
+        "ESC-003"
+      ],
+      "summary": "External requests should be separated by request type.",
+      "excerpt": "Timeline, evidence preservation, technical detail, and executive contact are distinct asks.",
+      "status": "external request",
+      "confidence": "high",
+      "source": "demo/source-corpus/emails.md#email-24"
+    },
+    {
+      "id": "EV-MEMO-04",
+      "type": "memo",
+      "date": "2026-07-21",
+      "participants": [
+        "Legal and Risk"
+      ],
+      "division": "Legal and Risk",
+      "escalationIds": [
+        "ESC-012"
+      ],
+      "summary": "Evidence states include reviewed, unreviewed, disputed, external request, and pending confirmation.",
+      "excerpt": "Low-confidence evidence may inform triage but may not justify a final recommendation.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/memos.md#memo-04"
+    },
+    {
+      "id": "EV-CHAT-02",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Bobbi",
+        "Susan Jacobs"
+      ],
+      "division": "HR",
+      "escalationIds": [
+        "ESC-005"
+      ],
+      "summary": "Payroll message confusion is a communications need, not a confirmed compromise.",
+      "excerpt": "Flag as communications need, not confirmed compromise.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/chats.md#chat-02"
+    },
+    {
+      "id": "EV-CHAT-03",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Samar Swailem",
+        "Angela Moss"
+      ],
+      "division": "E Coin",
+      "escalationIds": [
+        "ESC-002"
+      ],
+      "summary": "E Coin retry behavior is making fraud signals noisy.",
+      "excerpt": "Mark confidence medium until finance confirms customer behavior.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/chats.md#chat-03"
+    },
+    {
+      "id": "EV-CHAT-04",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Scott Knowles",
+        "Janet Robinson"
+      ],
+      "division": "E Healthcare",
+      "escalationIds": [
+        "ESC-004",
+        "ESC-006"
+      ],
+      "summary": "Recovery building access queue may affect patient operations.",
+      "excerpt": "Put it in executive brief if patient operations are affected.",
+      "status": "reviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/chats.md#chat-04"
+    },
+    {
+      "id": "EV-CHAT-05",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Gideon Goddard",
+        "Tyrell Wellick"
+      ],
+      "division": "Technology Operations",
+      "escalationIds": [
+        "ESC-009"
+      ],
+      "summary": "Third-party readiness note is incomplete.",
+      "excerpt": "Evidence status should show pending, not reviewed.",
+      "status": "pending",
+      "confidence": "high",
+      "source": "demo/source-corpus/chats.md#chat-05"
+    },
+    {
+      "id": "EV-CHAT-06",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Dominique DiPierro",
+        "Susan Jacobs"
+      ],
+      "division": "Legal and Risk",
+      "escalationIds": [
+        "ESC-003"
+      ],
+      "summary": "Agency request is for timeline, not root cause.",
+      "excerpt": "The app should separate those asks.",
+      "status": "external request",
+      "confidence": "high",
+      "source": "demo/source-corpus/chats.md#chat-06"
+    },
+    {
+      "id": "EV-CHAT-09",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Janet Robinson",
+        "Angela Moss"
+      ],
+      "division": "Executive Operations",
+      "escalationIds": [
+        "ESC-010"
+      ],
+      "summary": "Action owner and decision owner are distinct.",
+      "excerpt": "Action owner and decision owner.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/chats.md#chat-09"
+    },
+    {
+      "id": "EV-CHAT-11",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Samar Swailem",
+        "Tyrell Wellick"
+      ],
+      "division": "Bank of E",
+      "escalationIds": [
+        "ESC-001",
+        "ESC-002"
+      ],
+      "summary": "Bank of E and E Coin share some recovery signals.",
+      "excerpt": "Shared signal, separate escalation rows.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/chats.md#chat-11"
+    },
+    {
+      "id": "EV-CHAT-13",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Scott Knowles",
+        "Angela Moss"
+      ],
+      "division": "E Shipping",
+      "escalationIds": [
+        "ESC-007"
+      ],
+      "summary": "Shipping delays are operational unless threat evidence appears.",
+      "excerpt": "Category stays issue unless threat evidence appears.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/chats.md#chat-13"
+    },
+    {
+      "id": "EV-CHAT-14",
+      "type": "chat",
+      "date": "2026-07-21",
+      "participants": [
+        "Gideon Goddard",
+        "Susan Jacobs"
+      ],
+      "division": "Technology Operations",
+      "escalationIds": [
+        "ESC-008"
+      ],
+      "summary": "Third-party validation should not be overstated.",
+      "excerpt": "Add evidence confidence.",
+      "status": "pending",
+      "confidence": "low",
+      "source": "demo/source-corpus/chats.md#chat-14"
+    },
+    {
+      "id": "EV-SIGNAL-001",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Identity Recovery Portal"
+      ],
+      "division": "Bank of E",
+      "escalationIds": [
+        "ESC-001"
+      ],
+      "summary": "Identity recovery backlog blocks Bank of E account restoration.",
+      "excerpt": "Customer access restoration is delayed and support volume remains elevated.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/signals.json#SIG-001"
+    },
+    {
+      "id": "EV-SIGNAL-002",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "E Coin Ledger Monitoring"
+      ],
+      "division": "E Coin",
+      "escalationIds": [
+        "ESC-002"
+      ],
+      "summary": "E Coin fraud signal quality is inconsistent.",
+      "excerpt": "False positives may slow customer recovery while true fraud remains difficult to prioritize.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/signals.json#SIG-002"
+    },
+    {
+      "id": "EV-SIGNAL-003",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Legal Evidence Register"
+      ],
+      "division": "Legal and Risk",
+      "escalationIds": [
+        "ESC-003"
+      ],
+      "summary": "External agency asks for decision timeline.",
+      "excerpt": "Leadership needs a defensible timeline of evidence and decisions.",
+      "status": "external request",
+      "confidence": "high",
+      "source": "demo/source-corpus/signals.json#SIG-003"
+    },
+    {
+      "id": "EV-SIGNAL-004",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "E Healthcare Patient Portal"
+      ],
+      "division": "E Healthcare",
+      "escalationIds": [
+        "ESC-004"
+      ],
+      "summary": "Healthcare portal readiness is blocked by access review.",
+      "excerpt": "Patient-facing operations may be delayed unless access review is resolved.",
+      "status": "pending",
+      "confidence": "medium",
+      "source": "demo/source-corpus/signals.json#SIG-004"
+    },
+    {
+      "id": "EV-SIGNAL-005",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Employee Communications Queue"
+      ],
+      "division": "HR",
+      "escalationIds": [
+        "ESC-005"
+      ],
+      "summary": "Employee payroll phishing confusion.",
+      "excerpt": "Employees may trust incorrect payroll or benefits messages during recovery.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/signals.json#SIG-005"
+    },
+    {
+      "id": "EV-SIGNAL-006",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Recovery Site Access"
+      ],
+      "division": "E Corp Recovery Program",
+      "escalationIds": [
+        "ESC-006"
+      ],
+      "summary": "Recovery site building access queue delays operations.",
+      "excerpt": "Recovery teams cannot rotate staff efficiently across sites.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/signals.json#SIG-006"
+    },
+    {
+      "id": "EV-SIGNAL-007",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "E Shipping Routing Dashboard"
+      ],
+      "division": "E Shipping",
+      "escalationIds": [
+        "ESC-007"
+      ],
+      "summary": "Shipping delays are being over-classified as cyber incidents.",
+      "excerpt": "Incident queues are noisy and executives may misread operational delays as active threats.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/signals.json#SIG-007"
+    },
+    {
+      "id": "EV-SIGNAL-008",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Executive Briefing Workflow"
+      ],
+      "division": "Technology Operations",
+      "escalationIds": [
+        "ESC-008"
+      ],
+      "summary": "Unverified adversarial chatter references recovery systems.",
+      "excerpt": "Leadership needs awareness without treating unverified chatter as confirmed activity.",
+      "status": "pending",
+      "confidence": "low",
+      "source": "demo/source-corpus/signals.json#SIG-008"
+    },
+    {
+      "id": "EV-SIGNAL-009",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Legal Evidence Register"
+      ],
+      "division": "Technology Operations",
+      "escalationIds": [
+        "ESC-009"
+      ],
+      "summary": "Third-party assurance note is incomplete.",
+      "excerpt": "Executive brief cannot claim reviewed readiness for systems not inspected.",
+      "status": "pending",
+      "confidence": "high",
+      "source": "demo/source-corpus/signals.json#SIG-009"
+    },
+    {
+      "id": "EV-SIGNAL-010",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Executive Briefing Workflow"
+      ],
+      "division": "Executive Operations",
+      "escalationIds": [
+        "ESC-010"
+      ],
+      "summary": "Executive summaries lack owner and decision owner separation.",
+      "excerpt": "Escalations stall because action ownership and decision authority are blended.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/signals.json#SIG-010"
+    },
+    {
+      "id": "EV-SIGNAL-011",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "E Phone Support Console"
+      ],
+      "division": "E Phone",
+      "escalationIds": [
+        "ESC-011"
+      ],
+      "summary": "Support console recovery creates inconsistent customer guidance.",
+      "excerpt": "Support representatives may give inconsistent recovery instructions.",
+      "status": "unreviewed",
+      "confidence": "medium",
+      "source": "demo/source-corpus/signals.json#SIG-011"
+    },
+    {
+      "id": "EV-SIGNAL-012",
+      "type": "signal",
+      "date": "2026-07-21",
+      "participants": [
+        "Legal Evidence Register"
+      ],
+      "division": "Legal and Risk",
+      "escalationIds": [
+        "ESC-012"
+      ],
+      "summary": "Evidence review status is not visible in triage meetings.",
+      "excerpt": "Unreviewed evidence may be presented as settled fact.",
+      "status": "reviewed",
+      "confidence": "high",
+      "source": "demo/source-corpus/signals.json#SIG-012"
+    }
+  ],
+  "issueArtifacts": [
+    {
+      "id": "ISSUE-001",
+      "title": "Build Static App Shell",
+      "labels": [
+        "app-shell",
+        "verification"
+      ],
+      "milestone": "M1: Static command center",
+      "acceptanceCriteria": [
+        "app opens from index.html",
+        "tabs render for all five views",
+        "no framework or external service is required"
+      ],
+      "evidenceNeeded": [
+        "local browser smoke check"
+      ],
+      "implementationNotes": "Create the static app shell, navigation, and loading state.",
+      "simulatedCommits": [
+        "Create static app shell",
+        "Add tab navigation"
+      ],
+      "simulatedPr": "PR-001"
+    },
+    {
+      "id": "ISSUE-002",
+      "title": "Create App Seed Data",
+      "labels": [
+        "data"
+      ],
+      "milestone": "M1: Static command center",
+      "acceptanceCriteria": [
+        "corpus and issue artifacts are represented in app-seed.json",
+        "escalations link to evidence IDs",
+        "issue artifacts link to app features"
+      ],
+      "evidenceNeeded": [
+        "JSON validates",
+        "app loads data without errors"
+      ],
+      "implementationNotes": "Normalize the fictional source material into app-ready JSON.",
+      "simulatedCommits": [
+        "Add app seed data"
+      ],
+      "simulatedPr": "PR-002"
+    },
+    {
+      "id": "ISSUE-003",
+      "title": "Implement Command Center Queue",
+      "labels": [
+        "command-center",
+        "local-state"
+      ],
+      "milestone": "M1: Static command center",
+      "acceptanceCriteria": [
+        "queue shows core escalation fields",
+        "filters work across queue fields",
+        "owner and status can be changed locally"
+      ],
+      "evidenceNeeded": [
+        "manual filter and update check"
+      ],
+      "implementationNotes": "Render a dense triage queue with local workflow controls.",
+      "simulatedCommits": [
+        "Render command center queue",
+        "Add filters and local edits"
+      ],
+      "simulatedPr": "PR-003"
+    },
+    {
+      "id": "ISSUE-004",
+      "title": "Implement Evidence Feed",
+      "labels": [
+        "evidence",
+        "local-state"
+      ],
+      "milestone": "M2: Evidence and executive brief",
+      "acceptanceCriteria": [
+        "feed displays emails, memos, chats, and signals",
+        "evidence can be filtered by type and escalation",
+        "reviewed state can be toggled locally"
+      ],
+      "evidenceNeeded": [
+        "manual linked-evidence check"
+      ],
+      "implementationNotes": "Show source summaries and evidence status without exposing raw private data.",
+      "simulatedCommits": [
+        "Render evidence feed",
+        "Add reviewed state"
+      ],
+      "simulatedPr": "PR-004"
+    },
+    {
+      "id": "ISSUE-005",
+      "title": "Implement Executive Brief",
+      "labels": [
+        "executive-brief"
+      ],
+      "milestone": "M2: Evidence and executive brief",
+      "acceptanceCriteria": [
+        "brief shows top risks, heatmap, blockers, unresolved decisions, and recommended actions",
+        "brief does not include operational attack steps"
+      ],
+      "evidenceNeeded": [
+        "visual review"
+      ],
+      "implementationNotes": "Summarize the queue into a leadership-readable brief.",
+      "simulatedCommits": [
+        "Add executive brief",
+        "Add heatmap"
+      ],
+      "simulatedPr": "PR-005"
+    },
+    {
+      "id": "ISSUE-006",
+      "title": "Implement Fabricated Repo Page",
+      "labels": [
+        "repo-simulation"
+      ],
+      "milestone": "M3: Repo simulation and build trace",
+      "acceptanceCriteria": [
+        "page clearly labels the repo as fictional and local",
+        "issues show labels, milestone, criteria, and evidence needed",
+        "simulated commits and PRs can be shown or hidden"
+      ],
+      "evidenceNeeded": [
+        "manual toggle check"
+      ],
+      "implementationNotes": "Use local issue artifacts to simulate a repo page without GitHub calls.",
+      "simulatedCommits": [
+        "Add fabricated repo view",
+        "Add simulated PR toggle"
+      ],
+      "simulatedPr": "PR-006"
+    },
+    {
+      "id": "ISSUE-007",
+      "title": "Implement Build Trace",
+      "labels": [
+        "build-trace"
+      ],
+      "milestone": "M3: Repo simulation and build trace",
+      "acceptanceCriteria": [
+        "trace shows source corpus, OpenClaw planning, PRD, issue artifacts, goal prompt, implementation plan, and app output",
+        "each trace item has a short summary and source path"
+      ],
+      "evidenceNeeded": [
+        "visual review"
+      ],
+      "implementationNotes": "Make the workflow chain visible and reproducible.",
+      "simulatedCommits": [
+        "Add build trace timeline"
+      ],
+      "simulatedPr": "PR-007"
+    },
+    {
+      "id": "ISSUE-008",
+      "title": "Add Export And Reset",
+      "labels": [
+        "local-state",
+        "verification"
+      ],
+      "milestone": "M3: Repo simulation and build trace",
+      "acceptanceCriteria": [
+        "export returns JSON of local app state",
+        "reset clears local owner, status, notes, and reviewed changes",
+        "no external service is called"
+      ],
+      "evidenceNeeded": [
+        "manual export/reset check"
+      ],
+      "implementationNotes": "Keep all state in the browser and make it reversible.",
+      "simulatedCommits": [
+        "Add state export",
+        "Add reset control"
+      ],
+      "simulatedPr": "PR-008"
+    }
+  ],
+  "buildTrace": [
+    {
+      "id": "TRACE-001",
+      "step": "Source corpus",
+      "summary": "Fictional E Corp context, stakeholder brief, transcript, emails, memos, chats, people, systems, and signals.",
+      "source": "demo/source-corpus/"
+    },
+    {
+      "id": "TRACE-002",
+      "step": "OpenClaw planning",
+      "summary": "OpenClaw runs the planning and grill-with-docs loop before writing the PRD.",
+      "source": "demo/openclaw-prd-workflow.md"
+    },
+    {
+      "id": "TRACE-003",
+      "step": "PRD",
+      "summary": "The PRD defines the local command center, safety boundary, workshop flow, and acceptance criteria.",
+      "source": "PRD.md"
+    },
+    {
+      "id": "TRACE-004",
+      "step": "Issue artifacts",
+      "summary": "Implementation issues translate product requirements into scoped work.",
+      "source": "demo/issue-artifacts.md"
+    },
+    {
+      "id": "TRACE-005",
+      "step": "Goal prompt",
+      "summary": "The goal prompt starts the static app build with required sources, requirements, and checks.",
+      "source": "demo/goal-prompt.md"
+    },
+    {
+      "id": "TRACE-006",
+      "step": "Implementation plan",
+      "summary": "The implementation plan orders seed data, shell, app views, local state, slides, and verification.",
+      "source": "demo/implementation-plan.md"
+    },
+    {
+      "id": "TRACE-007",
+      "step": "App output",
+      "summary": "The final app gives attendees a local, inspectable command center with exportable state.",
+      "source": "demo/app/"
+    }
+  ],
+  "briefDefaults": {
+    "blockers": [
+      "Healthcare portal readiness is blocked by access review.",
+      "Third-party assurance note is incomplete.",
+      "Evidence review status is not visible in triage meetings."
+    ],
+    "unresolvedDecisions": [
+      "Who accepts residual risk for healthcare portal access review?",
+      "When should external timeline requests move from legal review to executive decision?",
+      "Which critical identity backlog items require business acceptance rather than engineering action?"
+    ],
+    "recommendedActions": [
+      "Review critical and high severity escalations first.",
+      "Separate action owner from decision owner in the triage queue.",
+      "Do not present unreviewed or low-confidence evidence as settled fact.",
+      "Export the local brief for human review before any follow-up communication."
+    ]
+  }
+};

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/index.html
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/index.html
@@ -70,6 +70,7 @@
     </section>
   </main>
 
+  <script src="data/app-seed.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds generated `data/app-seed.js` so the command center can load seed data directly from `file://`.
- Keeps `fetch("data/app-seed.json")` for served HTTP loads and falls back to the embedded seed when needed.
- Updates the load error copy for the rare case both sources are unavailable.

## Verification
- `app-seed.js` parity check against `app-seed.json`
- VM check: `file:` loader branch renders 12 escalations and does not call `fetch()`
- In-app browser check against `http://127.0.0.1:8765/`: 12 escalations load, filter narrows to 1 row, no relevant console warnings/errors
- `node scripts/check-external-links.mjs`
- `./scripts/publication-scan.sh`
- `node scripts/audit-repo.mjs`

## Notes
- In-app browser security policy blocks direct `file://` navigation, so the direct file-path behavior is covered by the loader-branch VM check.
- Repo audit still reports pre-existing warnings in older GitHub Build/Open Source Zone event materials.

Closes #57