### PR TITLE
Add slide-style icons to Personal AI Agents demo

### DIFF
--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
@@ -1,5 +1,55 @@
 const STORAGE_KEY = 'ecorp-command-center-state-v1';
 
+const ICONS = {
+  alert: '<path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/>',
+  brief: '<path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/>',
+  check: '<path d="M20 6 9 17l-5-5"/>',
+  code: '<path d="m16 18 6-6-6-6"/><path d="m8 6-6 6 6 6"/>',
+  command: '<rect x="3" y="4" width="18" height="14" rx="2"/><path d="M8 22h8"/><path d="M12 18v4"/>',
+  evidence: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/>',
+  export: '<path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/>',
+  repo: '<path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h10"/>',
+  scope: '<path d="M12 20V10"/><path d="M18 20V4"/><path d="M6 20v-4"/>',
+  shield: '<path d="M20 13c0 5-3.5 7.5-7.7 8.9a1 1 0 0 1-.6 0C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.2-2.5a1.3 1.3 0 0 1 1.6 0C14.5 3.8 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/>',
+  signal: '<path d="M21 15a4 4 0 0 1-4 4H7l-4 4V7a4 4 0 0 1 4-4h7"/><path d="M15 3h6v6"/><path d="m21 3-7 7"/>',
+  trace: '<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/><path d="M3 12c0 1.7 4 3 9 3s9-1.3 9-3"/>',
+  users: '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.9"/><path d="M16 3.1a4 4 0 0 1 0 7.8"/>',
+  workflow: '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/>'
+};
+
+const VIEW_ICONS = {
+  command: ['command', 'amber'],
+  evidence: ['evidence', 'blue'],
+  brief: ['brief', 'red'],
+  repo: ['repo', 'green'],
+  trace: ['trace', 'pink']
+};
+
+const METRIC_ICONS = {
+  'At risk': ['alert', 'amber'],
+  Blocked: ['alert', 'red'],
+  Critical: ['alert', 'red'],
+  Decisions: ['brief', 'blue'],
+  Issues: ['repo', 'green'],
+  Milestones: ['trace', 'blue'],
+  Open: ['repo', 'green'],
+  Reviewed: ['check', 'green'],
+  'Reviewed evidence': ['check', 'green'],
+  Shown: ['workflow', 'blue'],
+  'Simulated activity': ['code', 'pink'],
+  Types: ['evidence', 'blue']
+};
+
+const TRACE_ICONS = [
+  ['trace', ''],
+  ['signal', 'blue'],
+  ['evidence', ''],
+  ['repo', 'green'],
+  ['code', 'pink'],
+  ['command', 'amber'],
+  ['export', 'green']
+];
+
 const state = {
   data: null,
   activeTab: 'command',
@@ -23,10 +73,28 @@ const state = {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  decorateStaticIcons();
   state.local = loadLocalState();
   wireTabs();
   loadSeedData();
 });
+
+function decorateStaticIcons() {
+  document.querySelectorAll('.tab').forEach((button) => {
+    const [name, tone] = VIEW_ICONS[button.dataset.tab] || VIEW_ICONS.command;
+    if (!button.querySelector('.icon-badge')) {
+      button.insertAdjacentHTML('afterbegin', iconBadge(name, tone));
+    }
+  });
+
+  document.querySelectorAll('.view').forEach((view) => {
+    const [name, tone] = VIEW_ICONS[view.id] || VIEW_ICONS.command;
+    const heading = view.querySelector('.view-header h2');
+    if (heading && !heading.querySelector('.icon-badge')) {
+      heading.insertAdjacentHTML('afterbegin', iconBadge(name, tone));
+    }
+  });
+}
 
 function wireTabs() {
   document.querySelectorAll('.tab').forEach((button) => {
@@ -174,7 +242,8 @@ function renderEvidenceFeed(evidence, escalations) {
 function renderEvidenceCard(item) {
   return `
     <article class="evidence-card">
-      <div>
+      <div class="card-kicker">
+        ${iconBadge('evidence', 'blue')}
         <span class="tag">${escapeHtml(item.type)}</span>
         <span class="tag muted">${escapeHtml(item.status)}</span>
       </div>
@@ -205,23 +274,23 @@ function renderBriefShell(escalations) {
     </div>
     <div class="brief-layout">
       <section class="brief-card wide">
-        <h3>Top executive risks</h3>
+        ${sectionHeading('Top executive risks', 'brief', 'red')}
         <div class="stack">${top.map(renderTopRisk).join('')}</div>
       </section>
       <section class="brief-card">
-        <h3>Severity heatmap</h3>
+        ${sectionHeading('Severity heatmap', 'scope', 'amber')}
         ${renderHeatmap(escalations)}
       </section>
       <section class="brief-card">
-        <h3>Blockers</h3>
+        ${sectionHeading('Blockers', 'alert', 'red')}
         <ul>${blockers.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
       </section>
       <section class="brief-card">
-        <h3>Unresolved decisions</h3>
+        ${sectionHeading('Unresolved decisions', 'signal', 'blue')}
         <ul>${state.data.briefDefaults.unresolvedDecisions.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
       </section>
       <section class="brief-card">
-        <h3>Recommended next actions</h3>
+        ${sectionHeading('Recommended next actions', 'check', 'green')}
         <ul>${state.data.briefDefaults.recommendedActions.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
       </section>
     </div>
@@ -232,8 +301,11 @@ function renderRepoShell() {
   const artifacts = state.data.issueArtifacts;
   document.getElementById('repo-content').innerHTML = `
     <div class="notice">
-      <strong>Fabricated local repo:</strong>
-      <span>This view teaches issue breakdown. It does not call GitHub or create live issues, commits, or pull requests.</span>
+      ${iconBadge('repo', 'green')}
+      <div>
+        <strong>Fabricated local repo:</strong>
+        <span>This view teaches issue breakdown. It does not call GitHub or create live issues, commits, or pull requests.</span>
+      </div>
     </div>
     <div class="metric-row">
       ${metric('Issues', artifacts.length)}
@@ -249,14 +321,18 @@ function renderRepoShell() {
 function renderTraceShell() {
   document.getElementById('trace-content').innerHTML = `
     <ol class="trace-list">
-      ${state.data.buildTrace.map((item) => `
+      ${state.data.buildTrace.map((item, index) => {
+        const [iconName, tone] = TRACE_ICONS[index % TRACE_ICONS.length];
+        return `
         <li>
+          ${iconBadge(iconName, tone)}
           <span>${escapeHtml(item.id)}</span>
           <h3>${escapeHtml(item.step)}</h3>
           <p>${escapeHtml(item.summary)}</p>
           <code>${escapeHtml(item.source)}</code>
         </li>
-      `).join('')}
+      `;
+      }).join('')}
     </ol>
   `;
 }
@@ -305,8 +381,11 @@ function renderIssueArtifact(item) {
   return `
     <article class="issue-card">
       <header>
-        <span>${escapeHtml(item.id)}</span>
-        <strong>${escapeHtml(item.title)}</strong>
+        ${iconBadge('repo', 'green')}
+        <div>
+          <span>${escapeHtml(item.id)}</span>
+          <strong>${escapeHtml(item.title)}</strong>
+        </div>
       </header>
       <p>${escapeHtml(item.implementationNotes)}</p>
       <div class="tag-row">${item.labels.map((label) => `<span class="tag">${escapeHtml(label)}</span>`).join('')}</div>
@@ -486,7 +565,17 @@ function statusSelect(id, status) {
 }
 
 function metric(label, value) {
-  return `<div class="metric"><span>${escapeHtml(label)}</span><b>${escapeHtml(value)}</b></div>`;
+  const [name, tone] = METRIC_ICONS[label] || ['workflow', ''];
+  return `<div class="metric">${iconBadge(name, tone)}<span>${escapeHtml(label)}</span><b>${escapeHtml(value)}</b></div>`;
+}
+
+function sectionHeading(text, iconName, tone = '') {
+  return `<h3 class="section-title">${iconBadge(iconName, tone)}${escapeHtml(text)}</h3>`;
+}
+
+function iconBadge(name, tone = '') {
+  const toneClass = tone ? ` ${tone}` : '';
+  return `<span class="icon-badge${toneClass}" aria-hidden="true"><svg viewBox="0 0 24 24">${ICONS[name] || ICONS.workflow}</svg></span>`;
 }
 
 function reviewedEvidenceCount() {

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/styles.css
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/styles.css
@@ -150,6 +150,9 @@ h2 {
 }
 
 .tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
   min-height: 2.75rem;
   padding: 0.65rem 0.9rem;
   border: 1px solid var(--line);
@@ -171,6 +174,64 @@ h2 {
   color: #061018;
   border-color: var(--cyan);
   background: var(--cyan);
+}
+
+.tab.is-active .icon-badge {
+  color: var(--cyan);
+  background: #061018;
+}
+
+.icon-badge {
+  width: 2.125rem;
+  height: 2.125rem;
+  border-radius: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #071016;
+  background: var(--cyan);
+  flex: 0 0 auto;
+}
+
+.icon-badge.blue {
+  background: var(--blue);
+}
+
+.icon-badge.pink {
+  background: var(--pink);
+}
+
+.icon-badge.amber {
+  background: var(--amber);
+}
+
+.icon-badge.green {
+  background: var(--green);
+}
+
+.icon-badge.red {
+  background: var(--red);
+}
+
+.icon-badge svg {
+  width: 1.18rem;
+  height: 1.18rem;
+  stroke: currentColor;
+  stroke-width: 2.35;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.tab .icon-badge {
+  width: 1.55rem;
+  height: 1.55rem;
+  border-radius: 7px;
+}
+
+.tab .icon-badge svg {
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 .view {
@@ -195,6 +256,18 @@ h2 {
   margin-bottom: 1rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   padding-bottom: 1rem;
+}
+
+.view-header h2,
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.view-header h2 .icon-badge {
+  width: 2.35rem;
+  height: 2.35rem;
 }
 
 .placeholder {
@@ -232,6 +305,10 @@ h2 {
 }
 
 .metric {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  column-gap: 0.7rem;
   min-width: 9rem;
   padding: 0.8rem;
   border: 1px solid var(--line);
@@ -239,8 +316,16 @@ h2 {
   background: var(--panel);
 }
 
-.metric span {
+.metric .icon-badge {
+  grid-row: 1 / span 2;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 8px;
+}
+
+.metric span:not(.icon-badge) {
   display: block;
+  grid-column: 2;
   color: var(--faint);
   font-size: 0.78rem;
   text-transform: uppercase;
@@ -249,6 +334,7 @@ h2 {
 
 .metric b {
   display: block;
+  grid-column: 2;
   margin-top: 0.25rem;
   color: var(--text);
   font-size: 1.6rem;
@@ -456,6 +542,19 @@ td em {
   white-space: nowrap;
 }
 
+.card-kicker {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.card-kicker .icon-badge {
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 7px;
+}
+
 .brief-layout {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
@@ -562,6 +661,7 @@ td em {
 
 .notice {
   display: flex;
+  align-items: flex-start;
   gap: 0.5rem;
   margin-bottom: 1rem;
   padding: 0.9rem 1rem;
@@ -569,7 +669,18 @@ td em {
 }
 
 .notice strong {
+  display: block;
   color: var(--cyan);
+}
+
+.notice .icon-badge {
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 7px;
+}
+
+.notice span {
+  display: block;
 }
 
 .repo-grid {
@@ -586,10 +697,23 @@ td em {
 
 .issue-card header {
   display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.issue-card header .icon-badge {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 8px;
+}
+
+.issue-card header div {
+  display: grid;
   gap: 0.25rem;
 }
 
-.issue-card header span {
+.issue-card header div span {
   color: var(--cyan);
   font-size: 0.78rem;
   font-weight: 900;
@@ -645,7 +769,6 @@ td em {
   margin: 0;
   padding: 0;
   list-style: none;
-  counter-reset: trace;
 }
 
 .trace-list li {
@@ -656,21 +779,13 @@ td em {
   padding: 1rem;
 }
 
-.trace-list li::before {
-  counter-increment: trace;
-  content: counter(trace);
-  display: grid;
-  place-items: center;
-  grid-row: span 3;
+.trace-list .icon-badge {
+  grid-row: span 4;
   width: 2.4rem;
   height: 2.4rem;
-  border-radius: 999px;
-  color: #061018;
-  background: var(--cyan);
-  font-weight: 900;
 }
 
-.trace-list span {
+.trace-list li > span:not(.icon-badge) {
   color: var(--faint);
   font-size: 0.76rem;
   font-weight: 900;


### PR DESCRIPTION
## Summary
- Adds inline slide-style SVG icon badges to the Personal AI Agents LIVE demo app.
- Applies icons to tabs, view headings, metrics, evidence cards, executive brief sections, repo issue cards, and Build Trace items.
- Replaces generic numbered Build Trace circles with meaningful artifact-chain icons.

Closes #59.

## Verification
- `node --check event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js`
- Browser smoke at `http://127.0.0.1:8765/`: app loaded, 80 icon badges rendered, 5 tab icons, 5 view-heading icons, 7 trace icons, trace generated counters disabled, no console warnings/errors.
- Interaction smoke: Executive Brief tab icon sections rendered, Build Trace tab icon list rendered, Command Center search filtered to identity escalation.
- Mobile smoke at 390x844: app loaded, icons rendered, no page-level horizontal overflow, no console warnings/errors.
- `./scripts/publication-scan.sh`
- `node scripts/audit-repo.mjs`
- `node scripts/check-external-links.mjs`

## Notes
- No new runtime dependency. Icons are static inline SVG paths copied from the deck visual system.
- Existing repo audit/link-check warnings are unrelated older event warnings and bot-blocked external URLs.