### PR TITLE
Add GitHub Build business follow-up demo

### DIFF
--- a/event-specific/github-build-creators-2026-06-01/README.md
+++ b/event-specific/github-build-creators-2026-06-01/README.md
@@ -17,6 +17,7 @@ This is a short creator-facing OpenClaw overview and live demo. It is not a full
 - Demo script: [`demo-script.md`](demo-script.md)
 - Prompt pack: [`prompt-pack.md`](prompt-pack.md)
 - Demo files: [`demo/README.md`](demo/README.md)
+- Optional business demo: [`business-use-case-quick-demo.md`](business-use-case-quick-demo.md)
 - Day-before checklist: [`day-before-checklist.md`](day-before-checklist.md)
 - Fallback plan: [`fallback-plan.md`](fallback-plan.md)
 
@@ -40,6 +41,10 @@ Show creators what OpenClaw makes visible:
 | 8:30-10:00 | Close | Join Discord, where to find the OpenClaw team during Build week. |
 
 If the slot expands to 15 minutes, spend the extra time on creator-specific audience questions or the "what I would not automate" safety close.
+
+If the room leans founder/operator instead of creator-content, use
+[`business-use-case-quick-demo.md`](business-use-case-quick-demo.md) as the
+same OpenClaw pattern applied to a public-safe business follow-up packet.
 
 ## Core line
 

--- a/event-specific/github-build-creators-2026-06-01/business-use-case-quick-demo.md
+++ b/event-specific/github-build-creators-2026-06-01/business-use-case-quick-demo.md
@@ -1,0 +1,121 @@
+# Quick Business Use Case Demo
+
+Use this as the June 1 live-demo variant if Brad wants a real business use case
+instead of a pure creator-content scenario.
+
+## Recommended Scenario
+
+**Messy partner/customer conversation → reviewable follow-up packet.**
+
+Plain-English setup:
+
+> A small company leaves a conference conversation with scattered notes. They
+> need a clean follow-up email, an internal action checklist, and a verification
+> list without leaking private details or letting the agent send anything
+> automatically.
+
+Why this works for the June 1 audience:
+
+- creators understand follow-up content
+- founders/operators understand sales and partnership follow-up
+- it is business-real without needing private data
+- the artifact is quick to judge on screen
+- it shows context, bounded access, workflow, and verification in under 4 minutes
+
+## 30-Second Setup
+
+Say:
+
+> Here is a business version of the same OpenClaw pattern. Imagine a founder
+> or creator has a promising conference conversation. The raw notes are messy.
+> The goal is not to let an agent run the business. The goal is to turn
+> public-safe notes into a draft follow-up packet that a human can review.
+
+Show:
+
+1. [`demo/sample-public-business-followup-notes.md`](demo/sample-public-business-followup-notes.md)
+2. [`demo/business-followup-memory.md`](demo/business-followup-memory.md)
+3. [`demo/business-followup-prd.md`](demo/business-followup-prd.md)
+4. [`demo/business-followup-sop.md`](demo/business-followup-sop.md)
+
+## 3-Minute Live Run
+
+### Prompt 1 — Clarify
+
+```text
+Read the Business Follow-Up Memory, PRD, SOP, and sample public business notes.
+
+Before drafting anything, ask three clarifying questions that would help produce a useful business follow-up packet safely.
+
+Do not ask for private customer data, private DMs, contract terms, attendee contact details, credentials, unreleased announcements, or anything that should not appear in a public demo.
+```
+
+Answer quickly:
+
+```text
+1. Output: short follow-up email, internal action checklist, verification checklist.
+2. Tone: practical, warm, concise, not salesy.
+3. Boundary: use only the public-safe sample notes; do not invent names, prices, commitments, or dates.
+```
+
+### Prompt 2 — Create The Packet
+
+```text
+Act as a Business Follow-Up Planner.
+
+Using the Business Follow-Up Memory, PRD, SOP, sample notes, and my answers, create the smallest useful follow-up packet.
+
+Return:
+1. a draft follow-up email under 140 words,
+2. a 5-item internal action checklist,
+3. assumptions that require human confirmation,
+4. details that must stay out,
+5. approval checks before anything is sent.
+
+Keep it draft-only, practical, and concise.
+```
+
+### Prompt 3 — Verification Reviewer
+
+```text
+Act as a skeptical Verification Reviewer.
+
+Review the follow-up packet against the SOP.
+
+Return a short checklist of:
+1. facts to verify,
+2. wording that overpromises,
+3. missing context,
+4. sensitive details to remove,
+5. what a human must approve before sending.
+
+Do not rewrite the whole packet.
+```
+
+## What To Point Out While It Streams
+
+- The source notes are just Markdown, so the context is visible and reusable.
+- The PRD says what “good” means.
+- The SOP says what is not allowed.
+- The agent is producing a draft, not sending it.
+- The verification role is part of the workflow, not an afterthought.
+
+## Expected Screen-Worthy Output
+
+The best output should show:
+
+- a short email draft
+- a concrete action checklist
+- explicit assumptions
+- clear exclusions like pricing, private names, contact info, promises, and dates
+- human approval before sending
+
+## Close Line
+
+> That is the pattern: context, role, boundary, artifact, verification. OpenClaw makes that workflow visible enough to trust, reuse, and improve.
+
+## Fallback If Live Generation Is Slow
+
+Open [`demo/business-followup-expected-output.md`](demo/business-followup-expected-output.md) and say:
+
+> The exact words are not the product. The repeatable workflow is the product: visible context, bounded access, draft artifact, and verification before action.

--- a/event-specific/github-build-creators-2026-06-01/day-before-checklist.md
+++ b/event-specific/github-build-creators-2026-06-01/day-before-checklist.md
@@ -19,6 +19,7 @@ Use this on Sunday, May 31, 2026.
 - [ ] Open [`demo/creator-content-pack-prd.md`](demo/creator-content-pack-prd.md).
 - [ ] Open [`demo/creator-content-pack-sop.md`](demo/creator-content-pack-sop.md).
 - [ ] Open [`demo/expected-output.md`](demo/expected-output.md) as the fallback artifact.
+- [ ] Open [`business-use-case-quick-demo.md`](business-use-case-quick-demo.md) if the room may want a business follow-up example.
 - [ ] Confirm OpenClaw starts and the dashboard responds.
 - [ ] Confirm the model provider works.
 - [ ] Close unrelated apps, browser tabs, email, chat, and notifications.

--- a/event-specific/github-build-creators-2026-06-01/demo-script.md
+++ b/event-specific/github-build-creators-2026-06-01/demo-script.md
@@ -8,6 +8,10 @@ Creator conference recap to reusable content pack.
 
 The scenario is safe for a technical creator audience because it is concrete, easy to understand, and does not require private data.
 
+Optional variant: use [`business-use-case-quick-demo.md`](business-use-case-quick-demo.md)
+if the room is more interested in founder/operator follow-up than creator
+content.
+
 ## Universal Demo Pattern
 
 Use the same pattern from the prior InfraGard deck, shortened for the 10-minute slot:

--- a/event-specific/github-build-creators-2026-06-01/demo/README.md
+++ b/event-specific/github-build-creators-2026-06-01/demo/README.md
@@ -22,6 +22,18 @@ Turn public-safe Microsoft Build week notes into a small creator content pack:
 
 If live generation is slow, use [`expected-output.md`](expected-output.md) as the fallback artifact.
 
+## Optional business follow-up variant
+
+Use this variant when the audience is more founder/operator than
+creator-content focused:
+
+1. [`sample-public-business-followup-notes.md`](sample-public-business-followup-notes.md)
+2. [`business-followup-memory.md`](business-followup-memory.md)
+3. [`business-followup-prd.md`](business-followup-prd.md)
+4. [`business-followup-sop.md`](business-followup-sop.md)
+5. [`business-followup-expected-output.md`](business-followup-expected-output.md)
+6. [`../business-use-case-quick-demo.md`](../business-use-case-quick-demo.md)
+
 ## Safety boundary
 
 Do not paste secrets, API keys, tokens, credentials, private DMs, sponsor terms, attendee contact data, customer records, unreleased announcements, or private operational details into the demo.

--- a/event-specific/github-build-creators-2026-06-01/demo/business-followup-expected-output.md
+++ b/event-specific/github-build-creators-2026-06-01/demo/business-followup-expected-output.md
@@ -1,0 +1,49 @@
+# Expected Output: Business Follow-Up Packet Demo
+
+Use this if live generation is slow or network/model access is unreliable.
+
+## Draft Follow-Up Email
+
+Draft only. Review before sending.
+
+Hi — great talking with you about turning messy internal requests into reviewable action plans.
+
+The useful starting point seems to be a draft-only workflow: take public-safe intake notes, summarize the request, map next actions, and add a human review checklist before anything is sent to customers or changed in production.
+
+A safe next step would be a 20-minute discovery call where we walk through one synthetic example, such as turning an internal request into a decision brief and task checklist.
+
+No private customer data, contracts, credentials, or production systems are needed for that first pass.
+
+If useful, I can send a small example packet after Build week.
+
+## Internal Action Checklist
+
+1. Confirm the prospect's preferred follow-up channel before sending anything.
+2. Prepare one synthetic intake example: messy request → decision brief → task checklist.
+3. Keep the example draft-only and public-safe.
+4. Note approval gates for customer sends and production changes.
+5. Capture questions about integrations, governance, and rollout scope for the discovery call.
+
+## Assumptions To Verify
+
+- The prospect wants a 20-minute discovery call.
+- The synthetic workflow example is the right next step.
+- The audience is operations/product/support leadership, not only engineering.
+- The phrase "OpenClaw-style workflows" is clear enough for the recipient.
+- The follow-up should happen after Build week.
+
+## Details That Must Stay Out
+
+- Real company or person names unless approved.
+- Private emails, phone numbers, DMs, or attendee contact details.
+- Pricing, contract terms, sponsor details, or commitments.
+- Customer records, production details, credentials, or API keys.
+- Claims about integrations, delivery dates, or outcomes not supported by the notes.
+
+## Approval Checks Before Sending
+
+- Human verifies recipient, channel, and timing.
+- Human confirms no private details or invented commitments are included.
+- Human checks tone: practical, concise, not salesy.
+- Human approves any mention of next steps or example packets.
+- Human sends manually; the demo does not send, schedule, or post anything.

--- a/event-specific/github-build-creators-2026-06-01/demo/business-followup-memory.md
+++ b/event-specific/github-build-creators-2026-06-01/demo/business-followup-memory.md
@@ -1,0 +1,35 @@
+# Business Follow-Up Memory
+
+## Goal
+
+Turn public-safe conference conversation notes into a small, reviewable business follow-up packet.
+
+## Audience
+
+Founders, operators, creators, consultants, and technical leaders who need useful follow-up without exposing private information or overpromising.
+
+## Source Notes
+
+Use [`sample-public-business-followup-notes.md`](sample-public-business-followup-notes.md) as the only source material.
+
+## Business Context
+
+The example prospect wants to explore OpenClaw-style workflows for messy internal intake. They are interested in draft-only summaries, task maps, review checklists, and human approval gates.
+
+## Data Boundary
+
+Use public-safe synthetic notes only.
+
+Do not use or invent real names, contact details, private DMs, contract terms, pricing, customer data, credentials, unreleased announcements, or commitments.
+
+## Desired Output
+
+- a short follow-up email draft
+- an internal action checklist
+- assumptions to verify
+- details that must stay out
+- approval checks before sending
+
+## Review Standard
+
+The packet must be accurate, source-grounded, practical, draft-only, and reviewed by a human before any external send.

--- a/event-specific/github-build-creators-2026-06-01/demo/business-followup-prd.md
+++ b/event-specific/github-build-creators-2026-06-01/demo/business-followup-prd.md
@@ -1,0 +1,62 @@
+# PRD: Business Follow-Up Packet Demo
+
+## Problem
+
+Business conversations often end with scattered notes and vague next steps. A generic prompt can draft a polished email, but it may invent commitments, expose private details, or skip verification.
+
+## Goal
+
+Use OpenClaw to turn public-safe conversation notes into a small, reviewable follow-up packet.
+
+## Audience
+
+- founders
+- operators
+- consultants
+- creator-business owners
+- technical leaders
+- builders explaining OpenClaw to business stakeholders
+
+## User Story
+
+As a founder or operator, I want to turn public-safe conference conversation notes into a follow-up email and action checklist so I can move the opportunity forward without leaking private details or overpromising.
+
+## Scope
+
+In scope:
+
+- summarize public-safe notes
+- draft a short follow-up email
+- create an internal action checklist
+- identify assumptions that need human confirmation
+- identify sensitive or unsupported details to exclude
+- require human review before sending
+
+Out of scope:
+
+- sending the email
+- scheduling a meeting automatically
+- using real contact details
+- quoting prices or contract terms
+- promising integrations, delivery dates, or outcomes not supported by the notes
+- using private customer records, DMs, credentials, or unreleased announcements
+
+## Inputs
+
+- [`sample-public-business-followup-notes.md`](sample-public-business-followup-notes.md)
+- [`business-followup-memory.md`](business-followup-memory.md)
+- [`business-followup-sop.md`](business-followup-sop.md)
+
+## Acceptance Criteria
+
+- The agent asks clarifying questions before drafting.
+- The follow-up email is under 140 words.
+- The packet includes a 5-item internal action checklist.
+- The packet clearly marks assumptions for human confirmation.
+- The packet excludes private, unsupported, or invented details.
+- The packet says human approval is required before sending.
+- The output is clearly marked draft-only.
+
+## Quality Bar
+
+The output should feel like a practical founder/operator follow-up, not a generic sales email or product pitch.

--- a/event-specific/github-build-creators-2026-06-01/demo/business-followup-sop.md
+++ b/event-specific/github-build-creators-2026-06-01/demo/business-followup-sop.md
@@ -1,0 +1,46 @@
+# SOP: Build A Public-Safe Business Follow-Up Packet
+
+## Purpose
+
+Turn public-safe business conversation notes into a draft follow-up packet without exposing sensitive information, inventing commitments, or taking external action.
+
+## Prerequisites
+
+- Clean demo workspace.
+- Public-safe notes in Markdown.
+- PRD defining target output and boundaries.
+- No private DMs, credentials, contact records, pricing, contracts, customer data, unreleased announcements, or private operational details in the source notes.
+
+## Steps
+
+1. Open [`business-followup-memory.md`](business-followup-memory.md).
+2. Open [`business-followup-prd.md`](business-followup-prd.md).
+3. Open [`sample-public-business-followup-notes.md`](sample-public-business-followup-notes.md).
+4. Ask the agent to clarify before drafting.
+5. Ask for the smallest useful packet: follow-up email, internal checklist, assumptions, exclusions, approval checks.
+6. Ask a Verification Reviewer to challenge the packet before any send.
+7. Review manually before using anything externally.
+
+## Stop Conditions
+
+Stop the run if the agent:
+
+- asks for private or sensitive information
+- invents names, dates, prices, commitments, features, or outcomes
+- suggests sending, scheduling, posting, or changing external systems automatically
+- includes private contact details
+- ignores the PRD or data boundary
+- turns the packet into a hype-heavy sales pitch
+
+## Verification Checklist
+
+- Source notes support every claim.
+- No real names, contact details, pricing, contracts, credentials, customer data, or unreleased information appear.
+- No delivery promises or unsupported capability claims appear.
+- Tone is concise, practical, and not salesy.
+- The output is clearly draft-only.
+- A human has approved the packet before sending.
+
+## Handoff
+
+Save useful output back into the workspace as Markdown only after review. Do not send externally from the live demo.

--- a/event-specific/github-build-creators-2026-06-01/demo/sample-public-business-followup-notes.md
+++ b/event-specific/github-build-creators-2026-06-01/demo/sample-public-business-followup-notes.md
@@ -1,0 +1,36 @@
+# Sample Public Business Follow-Up Notes
+
+Use these notes for the quick business-use-case demo. They are intentionally synthetic and public-safe.
+
+## Scenario
+
+A founder/creator had a short conference-floor conversation with an operations lead from a growing software company.
+
+The operations lead is interested in using OpenClaw-style workflows to turn messy internal requests into reviewable action plans.
+
+## Public-Safe Conversation Notes
+
+- The company has repeated intake from support, sales, and product teams.
+- Requests arrive in different places and lose context before anyone acts.
+- They want draft-only help first: summaries, task maps, and review checklists.
+- They care about human approval before anything is sent to customers or changed in production.
+- A safe next step would be a 20-minute discovery call and a small synthetic workflow example.
+- Good example workflow: turn a messy internal request into a decision brief and task checklist.
+
+## Boundaries
+
+Do not include:
+
+- real company name
+- real person name
+- private email address or phone number
+- pricing
+- contract terms
+- private customer records
+- credentials or API keys
+- unreleased announcements
+- promises about capabilities not shown in the notes
+
+## Desired Tone
+
+Warm, practical, concise, and not salesy.

--- a/event-specific/github-build-creators-2026-06-01/facilitator-runbook.md
+++ b/event-specific/github-build-creators-2026-06-01/facilitator-runbook.md
@@ -45,6 +45,9 @@ Use [`demo-script.md`](demo-script.md).
 
 If the live demo slows down, switch immediately to [`fallback-plan.md`](fallback-plan.md).
 
+If the room is asking business-ops questions, switch to the optional
+[`business-use-case-quick-demo.md`](business-use-case-quick-demo.md) path.
+
 ## Public safety
 
 Do not paste secrets, API keys, tokens, credentials, private DMs, sponsor terms, attendee contact data, customer records, unreleased announcements, or private operational details into the demo.

--- a/event-specific/github-build-creators-2026-06-01/fallback-plan.md
+++ b/event-specific/github-build-creators-2026-06-01/fallback-plan.md
@@ -32,6 +32,8 @@ Then walk through [`prompt-pack.md`](prompt-pack.md) as a prompt-read demo:
 
 - Use the local HTML deck or PDF.
 - Use [`demo/expected-output.md`](demo/expected-output.md) as the staged text output.
+- Use [`demo/business-followup-expected-output.md`](demo/business-followup-expected-output.md)
+  if you chose the business follow-up variant.
 - Point to the repo and Discord verbally.
 
 ## If Time Is Cut To 5 Minutes


### PR DESCRIPTION
## Summary

Adds the optional public-safe business follow-up demo variant to the June 1 GitHub Build Creators packet.

Closes #65.

## What Changed

- Added `business-use-case-quick-demo.md` as a presenter script for a founder/operator-oriented follow-up workflow.
- Added repo-backed demo files for the business variant: sample notes, memory, PRD, SOP, and expected output.
- Linked the optional path from the event README, demo README, demo script, facilitator runbook, fallback plan, and day-before checklist.
- Kept the existing creator-content demo as the primary path.

## Why

The files were coherent, public-safe, and useful as an alternate demo for a room more interested in business operations than creator content. Wiring them into the packet is better than leaving them as local-only orphan files.

## Validation

- `git diff --check`
- `git diff --check --cached`
- `./scripts/publication-scan.sh`
- `node scripts/audit-repo.mjs`

## Notes

- Repo audit still reports the existing unrelated past-date warnings for older planned event packets.
