### PR TITLE
Finalize Personal AI event-day instructions

### DIFF
--- a/event-specific/personal-ai-agents-live-2026-07-21/PRD.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/PRD.md
@@ -14,8 +14,8 @@ Codex owns the issue-artifact prompt, `/goal` prompt, implementation plan, and s
 
 - Personal AI Agents LIVE is a July 21, 2026 live online ODSC AI event about personal AI systems, assistants, agent workflows, context, trust, and work interfaces.
 - The confirmed workshop format is a 45-minute hands-on OpenClaw session for a developer and builder audience.
-- The working title is "Using Personal AI in 2026: OpenClaw and the New Developer Workflow."
-- The public schedule still needs to reflect Brad's exact slot and session details.
+- The public title is "Using Personal AI in 2026: OpenClaw and the New Developer Workflow."
+- The public schedule lists Brad's workshop for 3:20-4:05 PM EST on July 21, 2026.
 - The demo universe is E Corp from Mr. Robot, using canonical people and divisions as fictional training context.
 - The canonical reference describes E Corp as a large conglomerate with technology, finance, healthcare, shipping, and consumer divisions.
 - The workshop uses post-5/9 recovery pressure as the scenario backdrop, with realistic but non-operational cyber risk content.
@@ -234,11 +234,11 @@ Use local files only:
 | Live corpus generation takes too long | Generate only a small slice, then use the full checked-in corpus. |
 | Audience fixates on Mr. Robot canon | Keep canon as flavor; keep product decisions grounded in workshop goals. |
 | Security content becomes too operational | Use risk and governance language, not attack instructions. |
-| Codex build exceeds session time | Use the app-output spec and fallback implementation plan as the teaching artifact. |
+| Codex build exceeds session time | Open the completed local app, then use the app-output spec and implementation plan to explain the build decisions. |
 | Presentation work drifts into marketing | Keep slides focused on workflow proof, not product hype. |
 | Static app feels too small | Include interactive local workflow controls and export state. |
 | Simulated repo confuses attendees | Label it clearly as local/fabricated and avoid live GitHub actions. |
-| Public schedule mismatch remains | Keep exact slot and public listing as organizer follow-up. |
+| Organizer changes the public slot after packet freeze | Recheck https://summit.ai/#schedule during the day-before review and update the event entry points together. |
 
 ## Acceptance Criteria
 
@@ -251,10 +251,10 @@ Use local files only:
 - The presentation follows prior event guidance: HTML source first, PDF export second, dark local deck, explicit safety slide, and separate speaker notes.
 - The repo audit and publication scan pass or any remaining failures are documented.
 
-## Open Questions
+## Resolved Delivery Decisions
 
-- Confirm final public schedule slot and title.
-- Confirm whether the static app should be built before the event packet is published or generated live only.
-- Confirm whether slides should be created before the first app build or after the app output exists.
-- Confirm whether simulated commits/PRs should be on by default or hidden behind a toggle.
-- Confirm whether root README and START-HERE should list this packet after the schedule is public.
+- The public title and 3:20-4:05 PM EST slot are confirmed on the organizer's schedule.
+- The static app is checked in as the reliable workshop artifact; a small slice may still be generated live when conditions allow.
+- The HTML deck, PDF export, and speaker notes are checked in after the app output was finalized.
+- Simulated commits and pull requests are enabled by default behind a visible toggle.
+- The root README and `event-specific/events.json` list this public packet.

--- a/event-specific/personal-ai-agents-live-2026-07-21/README.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/README.md
@@ -1,7 +1,10 @@
 # Personal AI Agents LIVE OpenClaw Workshop
 
 Date: July 21, 2026
+Time: 3:20-4:05 PM EST, as published by the organizer
+Session: Using Personal AI in 2026: OpenClaw and the New Developer Workflow
 Format: live online workshop
+Event page and schedule: https://summit.ai/#schedule
 Audience: developers, technical builders, security practitioners, product leaders, and AI workflow adopters
 
 This packet supports a 45-minute workshop showing the full path from messy stakeholder discovery to a working app.
@@ -32,6 +35,10 @@ This packet supports a 45-minute workshop showing the full path from messy stake
 - Slides: [slides.html](slides.html)
 - PDF deck: [slides.pdf](slides.pdf)
 - Speaker notes: [speaker-notes-45-minute.md](speaker-notes-45-minute.md)
+- Facilitator runbook: [facilitator-runbook.md](facilitator-runbook.md)
+- Day-before checklist: [day-before-checklist.md](day-before-checklist.md)
+- Fallback plan: [fallback-plan.md](fallback-plan.md)
+- Attendee links: [attendee-links.md](attendee-links.md)
 
 ## Demo Outcome
 

--- a/event-specific/personal-ai-agents-live-2026-07-21/attendee-links.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/attendee-links.md
@@ -2,6 +2,12 @@
 
 Use these links after the workshop to recreate the workflow.
 
+## Event
+
+- Session: **Using Personal AI in 2026: OpenClaw and the New Developer Workflow**
+- Date and time: **July 21, 2026, 3:20-4:05 PM EST**, as published by the organizer
+- Public event page and schedule: https://summit.ai/#schedule
+
 ## Event Packet
 
 - Workshop README: [README.md](README.md)

--- a/event-specific/personal-ai-agents-live-2026-07-21/day-before-checklist.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/day-before-checklist.md
@@ -1,5 +1,7 @@
 # Day-Before Checklist
 
+Confirmed public session: **Using Personal AI in 2026: OpenClaw and the New Developer Workflow**, July 21, 2026, **3:20-4:05 PM EST** as published at https://summit.ai/#schedule.
+
 - [ ] Open [README.md](README.md).
 - [ ] Open [PRD.md](PRD.md).
 - [ ] Open [prompt-pack.md](prompt-pack.md).
@@ -9,13 +11,15 @@
 - [ ] Open [demo/goal-prompt.md](demo/goal-prompt.md).
 - [ ] Open [demo/presentation-prompt.md](demo/presentation-prompt.md).
 - [ ] Open [demo/app-output-spec.md](demo/app-output-spec.md).
-- [ ] Confirm `slides.html` and `slides.pdf` exist if presentation generation has already run.
-- [ ] Confirm speaker notes exist if presentation generation has already run.
+- [ ] Open [slides.html](slides.html) and confirm all 15 slides, hash navigation, arrows, and dark/light toggle work.
+- [ ] Open [slides.pdf](slides.pdf) and confirm all 15 pages and external links render correctly.
+- [ ] Open [speaker-notes-45-minute.md](speaker-notes-45-minute.md) and verify the slide sequence against the deck.
+- [ ] Open [demo/app/index.html](demo/app/index.html) directly and confirm 12 escalations and all five views load.
 - [ ] Confirm OpenClaw is ready for a live planning run.
 - [ ] Confirm Codex is ready for issue, goal, and app-build work.
 - [ ] Prepare a clean browser window for the static app.
 - [ ] Prepare fallback narration if live generation is slow.
-- [ ] Confirm the public event schedule and final title.
+- [ ] Recheck https://summit.ai/#schedule for organizer changes to the confirmed title or 3:20-4:05 PM EST slot.
 
 ## Safety Check
 

--- a/event-specific/personal-ai-agents-live-2026-07-21/fallback-plan.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/fallback-plan.md
@@ -18,12 +18,14 @@ Use checked-in issue artifacts, goal prompt, and implementation plan.
 
 ### Level 4: App Fallback
 
-If live app build is slow, use [demo/app-output-spec.md](demo/app-output-spec.md) and walk through the expected static app behavior.
+If the live app build is slow, open the completed [demo/app/index.html](demo/app/index.html) and demonstrate the checked-in static app.
+Use [demo/app-output-spec.md](demo/app-output-spec.md) and [demo/implementation-plan.md](demo/implementation-plan.md) to explain the build decisions or narrate the behavior if browser presentation fails.
 
 ### Level 5: Presentation Fallback
 
-If slides are not ready, use [PRD.md](PRD.md), [demo/openclaw-prd-workflow.md](demo/openclaw-prd-workflow.md), and [demo/app-output-spec.md](demo/app-output-spec.md) as the talk track.
-Prior events use `slides.html` and `slides.pdf`, but the workflow docs can carry the session if deck generation is behind.
+Use [slides.html](slides.html) as the primary deck and [slides.pdf](slides.pdf) if the HTML presentation cannot run.
+If neither deck surface is available, use [speaker-notes-45-minute.md](speaker-notes-45-minute.md), [PRD.md](PRD.md),
+[demo/openclaw-prd-workflow.md](demo/openclaw-prd-workflow.md), and [demo/app-output-spec.md](demo/app-output-spec.md) as the offline talk track.
 
 ## Preserve
 

--- a/event-specific/personal-ai-agents-live-2026-07-21/speaker-notes-45-minute.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/speaker-notes-45-minute.md
@@ -49,7 +49,7 @@ These notes support [slides.html](slides.html). Keep the live workflow ahead of 
 
 ## 23:00-26:00 - Slide 9: Issue Artifacts
 
-- Show the issue artifacts and live GitHub issue set.
+- Show `demo/issue-artifacts.md` and the app's Fabricated Repo view. If the historical implementation issues are useful, show them read-only and make clear that the workshop does not create or modify live GitHub issues.
 - Explain dependencies: escalation data first, command workflow second, local proof and Build Trace last.
 - Keep the message practical: good issues make the build reviewable.
 


### PR DESCRIPTION
## Summary

- record the confirmed public session title, schedule, and event link
- replace pre-build checklist and fallback branches with the checked-in app, deck, PDF, and notes
- direct the issue-artifact segment to local, read-only workshop surfaces

## Verification

- `bash scripts/publication-scan.sh` on an exported tree without worktree metadata
- `node scripts/audit-repo.mjs`
- `node scripts/check-external-links.mjs`
- `git diff --check`
- stale event-day wording scan

Closes #87
