### PR TITLE
Automate Personal AI seed fallback checks

### DIFF
--- a/event-specific/events.json
+++ b/event-specific/events.json
@@ -111,6 +111,7 @@
         "event-specific/personal-ai-agents-live-2026-07-21/demo/app/styles.css",
         "event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js",
         "event-specific/personal-ai-agents-live-2026-07-21/demo/app/data/app-seed.json",
+        "event-specific/personal-ai-agents-live-2026-07-21/demo/app/data/app-seed.js",
         "event-specific/personal-ai-agents-live-2026-07-21/demo/source-corpus/company-brief.md",
         "event-specific/personal-ai-agents-live-2026-07-21/demo/source-corpus/stakeholder-brief.md",
         "event-specific/personal-ai-agents-live-2026-07-21/demo/source-corpus/discovery-transcript.md",

--- a/event-specific/personal-ai-agents-live-2026-07-21/README.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/README.md
@@ -48,6 +48,23 @@ The app includes a command center, evidence feed, executive brief, fabricated re
 
 The final packet also includes a local HTML slide deck, PDF export, and 45-minute speaker notes.
 
+## Seed Data
+
+[`demo/app/data/app-seed.json`](demo/app/data/app-seed.json) is the canonical app seed.
+After editing it, regenerate the direct-file fallback from the repository root:
+
+```bash
+node scripts/sync-personal-ai-agents-seed.mjs
+```
+
+Verify parity without writing files:
+
+```bash
+node scripts/sync-personal-ai-agents-seed.mjs --check
+```
+
+The repository audit runs the same parity and 12-escalation check.
+
 ## Safety Boundary
 
 Do not paste secrets, API keys, tokens, credentials, real personal data, real customer records, live incident details, or non-public work material into the demo.

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app-output-spec.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app-output-spec.md
@@ -12,6 +12,7 @@ Static local app:
 - `styles.css`
 - `app.js`
 - `data/app-seed.json`
+- `data/app-seed.js`, generated from the canonical JSON for direct `file://` launch
 
 No framework, backend, database, auth, or external services.
 

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/implementation-plan.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/implementation-plan.md
@@ -6,7 +6,7 @@ Build a static, local-only E Corp Cyber Escalation Command Center app for the wo
 
 ## Steps
 
-1. Convert source corpus and issue artifacts into `demo/app/data/app-seed.json`.
+1. Convert source corpus and issue artifacts into `demo/app/data/app-seed.json`, then run `node scripts/sync-personal-ai-agents-seed.mjs` from the repository root to regenerate the direct-file fallback.
 2. Create static app shell with semantic tabs.
 3. Add command center queue with filters and local workflow controls.
 4. Add evidence feed linked to escalation IDs.

--- a/scripts/audit-repo.mjs
+++ b/scripts/audit-repo.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
 import path from 'node:path'
+import { verifyEmbeddedSeed } from './sync-personal-ai-agents-seed.mjs'
 
 const root = process.cwd()
 const skipDirectories = new Set(['.git', 'node_modules', 'dist', '.vite'])
@@ -332,11 +333,20 @@ function validateAppScripts() {
   }
 }
 
+function validatePersonalAiAgentsSeed() {
+  try {
+    verifyEmbeddedSeed(root)
+  } catch (error) {
+    failures.push(`Personal AI Agents seed fallback check failed: ${error.message}`)
+  }
+}
+
 walk(root)
 validateRequiredFiles()
 validateAppScripts()
 validateBeaverBadgesData()
 validateEventMetadata()
+validatePersonalAiAgentsSeed()
 
 const linkFiles = files.filter((file) => file.endsWith('.md') || file.endsWith('.html'))
 for (const file of linkFiles) {

--- a/scripts/sync-personal-ai-agents-seed.mjs
+++ b/scripts/sync-personal-ai-agents-seed.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import vm from 'node:vm'
+import { fileURLToPath } from 'node:url'
+
+export const seedJsonPath = 'event-specific/personal-ai-agents-live-2026-07-21/demo/app/data/app-seed.json'
+export const embeddedSeedPath = 'event-specific/personal-ai-agents-live-2026-07-21/demo/app/data/app-seed.js'
+
+const header = '// Generated from app-seed.json so the demo can run directly from file://.\n'
+
+export function buildEmbeddedSeed(seedData) {
+  return `${header}window.ECORP_APP_SEED = ${JSON.stringify(seedData, null, 2)};\n`
+}
+
+function readSeedData(root) {
+  const fullJsonPath = path.join(root, seedJsonPath)
+  if (!fs.existsSync(fullJsonPath)) {
+    throw new Error(`missing canonical seed: ${seedJsonPath}`)
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(fullJsonPath, 'utf8'))
+  } catch (error) {
+    throw new Error(`invalid canonical seed JSON: ${error.message}`)
+  }
+}
+
+function evaluateEmbeddedSeed(source) {
+  const context = { window: {} }
+  vm.runInNewContext(source, context, { filename: embeddedSeedPath })
+  return context.window.ECORP_APP_SEED
+}
+
+export function verifyEmbeddedSeed(root = process.cwd()) {
+  const seedData = readSeedData(root)
+  const fullEmbeddedPath = path.join(root, embeddedSeedPath)
+  if (!fs.existsSync(fullEmbeddedPath)) {
+    throw new Error(`missing direct-file seed fallback: ${embeddedSeedPath}`)
+  }
+
+  const actual = fs.readFileSync(fullEmbeddedPath, 'utf8')
+  const expected = buildEmbeddedSeed(seedData)
+  if (actual !== expected) {
+    throw new Error(`direct-file seed fallback is out of sync; run node scripts/sync-personal-ai-agents-seed.mjs`)
+  }
+
+  let embeddedSeed
+  try {
+    embeddedSeed = evaluateEmbeddedSeed(actual)
+  } catch (error) {
+    throw new Error(`direct-file seed fallback is not executable: ${error.message}`)
+  }
+
+  if (JSON.stringify(embeddedSeed) !== JSON.stringify(seedData)) {
+    throw new Error('direct-file seed fallback does not expose the canonical seed data')
+  }
+
+  if (embeddedSeed?.escalations?.length !== 12) {
+    throw new Error(`direct-file seed fallback must expose 12 escalations; found ${embeddedSeed?.escalations?.length ?? 0}`)
+  }
+
+  return { escalationCount: embeddedSeed.escalations.length }
+}
+
+export function syncEmbeddedSeed(root = process.cwd()) {
+  const seedData = readSeedData(root)
+  const fullEmbeddedPath = path.join(root, embeddedSeedPath)
+  const expected = buildEmbeddedSeed(seedData)
+  const current = fs.existsSync(fullEmbeddedPath) ? fs.readFileSync(fullEmbeddedPath, 'utf8') : null
+
+  if (current === expected) return { changed: false }
+
+  fs.writeFileSync(fullEmbeddedPath, expected)
+  return { changed: true }
+}
+
+function runCli() {
+  const mode = process.argv[2] ?? '--write'
+  if (!['--write', '--check'].includes(mode) || process.argv.length > 3) {
+    console.error('Usage: node scripts/sync-personal-ai-agents-seed.mjs [--write|--check]')
+    process.exit(2)
+  }
+
+  try {
+    if (mode === '--check') {
+      const result = verifyEmbeddedSeed()
+      console.log(`Personal AI Agents seed fallback matches the canonical JSON (${result.escalationCount} escalations).`)
+      return
+    }
+
+    const result = syncEmbeddedSeed()
+    const verification = verifyEmbeddedSeed()
+    console.log(
+      `${result.changed ? 'Updated' : 'No change to'} Personal AI Agents seed fallback (${verification.escalationCount} escalations).`,
+    )
+  } catch (error) {
+    console.error(`Personal AI Agents seed fallback check failed: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+const invokedPath = process.argv[1] ? fs.realpathSync(path.resolve(process.argv[1])) : null
+const modulePath = fs.realpathSync(fileURLToPath(import.meta.url))
+if (invokedPath === modulePath) {
+  runCli()
+}


### PR DESCRIPTION
## Summary

- add a deterministic generator and check for the direct-file seed fallback
- fail the repository audit when the embedded seed is missing, stale, invalid, or does not expose 12 escalations
- register the embedded seed as a required event file and document the regeneration workflow

## Verification

- `node scripts/sync-personal-ai-agents-seed.mjs --check`
- repeated generation produced identical file hashes
- deliberate fixture drift failed, then the generator repaired it
- served browser loaded 12 escalations and all five views with no console warnings or errors
- `bash scripts/publication-scan.sh` on an exported tree without worktree metadata
- `node scripts/audit-repo.mjs`
- `node scripts/check-external-links.mjs`
- `git diff --check`

Closes #88
