### PR TITLE
Add accessible Personal AI app tabs

### DIFF
--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app-output-spec.md
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app-output-spec.md
@@ -18,6 +18,8 @@ No framework, backend, database, auth, or external services.
 
 ## Navigation
 
+The five primary views use an accessible automatic-activation tab pattern. Left and Right Arrow move between adjacent tabs, Home and End move to the first and last tabs, and inactive panels remain hidden from assistive technology.
+
 ### Command Center
 
 Purpose: triage cyber risks, issues, and threats.

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js
@@ -97,20 +97,48 @@ function decorateStaticIcons() {
 }
 
 function wireTabs() {
-  document.querySelectorAll('.tab').forEach((button) => {
+  const tabList = document.querySelector('[role="tablist"]');
+  const tabs = [...document.querySelectorAll('[role="tab"]')];
+
+  tabs.forEach((button) => {
     button.addEventListener('click', () => setActiveTab(button.dataset.tab));
+  });
+
+  tabList?.addEventListener('keydown', (event) => {
+    const currentTab = event.target.closest?.('[role="tab"]');
+    if (!currentTab) return;
+
+    const currentIndex = tabs.indexOf(currentTab);
+    let nextIndex = null;
+    if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % tabs.length;
+    if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = tabs.length - 1;
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    setActiveTab(nextTab.dataset.tab);
+    nextTab.focus({ preventScroll: true });
   });
 }
 
 function setActiveTab(tabName) {
+  const tabs = [...document.querySelectorAll('[role="tab"]')];
+  if (!tabs.some((button) => button.dataset.tab === tabName)) return;
+
   state.activeTab = tabName;
-  document.querySelectorAll('.tab').forEach((button) => {
-    button.classList.toggle('is-active', button.dataset.tab === tabName);
+  tabs.forEach((button) => {
+    const isActive = button.dataset.tab === tabName;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-selected', String(isActive));
+    button.tabIndex = isActive ? 0 : -1;
   });
   document.querySelectorAll('.view').forEach((view) => {
-    view.classList.toggle('is-active', view.id === tabName);
+    const isActive = view.id === tabName;
+    view.classList.toggle('is-active', isActive);
+    view.hidden = !isActive;
   });
-  document.getElementById(tabName)?.focus({ preventScroll: true });
 }
 
 async function loadSeedData() {

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/index.html
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/index.html
@@ -21,15 +21,15 @@
   </header>
 
   <main class="app-shell">
-    <nav class="tabs" aria-label="Command center views">
-      <button class="tab is-active" type="button" data-tab="command">Command Center</button>
-      <button class="tab" type="button" data-tab="evidence">Evidence Feed</button>
-      <button class="tab" type="button" data-tab="brief">Executive Brief</button>
-      <button class="tab" type="button" data-tab="repo">Fabricated Repo</button>
-      <button class="tab" type="button" data-tab="trace">Build Trace</button>
+    <nav class="tabs" role="tablist" aria-label="Command center views" aria-orientation="horizontal">
+      <button id="tab-command" class="tab is-active" type="button" role="tab" aria-controls="command" aria-selected="true" data-tab="command">Command Center</button>
+      <button id="tab-evidence" class="tab" type="button" role="tab" aria-controls="evidence" aria-selected="false" tabindex="-1" data-tab="evidence">Evidence Feed</button>
+      <button id="tab-brief" class="tab" type="button" role="tab" aria-controls="brief" aria-selected="false" tabindex="-1" data-tab="brief">Executive Brief</button>
+      <button id="tab-repo" class="tab" type="button" role="tab" aria-controls="repo" aria-selected="false" tabindex="-1" data-tab="repo">Fabricated Repo</button>
+      <button id="tab-trace" class="tab" type="button" role="tab" aria-controls="trace" aria-selected="false" tabindex="-1" data-tab="trace">Build Trace</button>
     </nav>
 
-    <section id="command" class="view is-active" tabindex="-1">
+    <section id="command" class="view is-active" role="tabpanel" aria-labelledby="tab-command" tabindex="0">
       <div class="view-header">
         <p class="eyebrow">Triage queue</p>
         <h2>Command Center</h2>
@@ -37,7 +37,7 @@
       <div id="command-content" class="placeholder"></div>
     </section>
 
-    <section id="evidence" class="view" tabindex="-1">
+    <section id="evidence" class="view" role="tabpanel" aria-labelledby="tab-evidence" tabindex="0" hidden>
       <div class="view-header">
         <p class="eyebrow">Linked source material</p>
         <h2>Evidence Feed</h2>
@@ -45,7 +45,7 @@
       <div id="evidence-content" class="placeholder"></div>
     </section>
 
-    <section id="brief" class="view" tabindex="-1">
+    <section id="brief" class="view" role="tabpanel" aria-labelledby="tab-brief" tabindex="0" hidden>
       <div class="view-header">
         <p class="eyebrow">Leadership summary</p>
         <h2>Executive Brief</h2>
@@ -53,7 +53,7 @@
       <div id="brief-content" class="placeholder"></div>
     </section>
 
-    <section id="repo" class="view" tabindex="-1">
+    <section id="repo" class="view" role="tabpanel" aria-labelledby="tab-repo" tabindex="0" hidden>
       <div class="view-header">
         <p class="eyebrow">Local simulation</p>
         <h2>Fabricated Repo</h2>
@@ -61,7 +61,7 @@
       <div id="repo-content" class="placeholder"></div>
     </section>
 
-    <section id="trace" class="view" tabindex="-1">
+    <section id="trace" class="view" role="tabpanel" aria-labelledby="tab-trace" tabindex="0" hidden>
       <div class="view-header">
         <p class="eyebrow">Artifact chain</p>
         <h2>Build Trace</h2>

--- a/event-specific/personal-ai-agents-live-2026-07-21/demo/app/styles.css
+++ b/event-specific/personal-ai-agents-live-2026-07-21/demo/app/styles.css
@@ -248,6 +248,11 @@ h2 {
   display: block;
 }
 
+.view:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 4px;
+}
+
 .view-header {
   display: flex;
   align-items: end;


### PR DESCRIPTION
## Summary

- expose the five primary views as a related tablist, tabs, and tabpanels
- synchronize selected state, roving tab order, and hidden panels with the visual state
- add automatic Left/Right/Home/End navigation and keep focus on the selected tab
- document the keyboard contract and add visible panel focus treatment

## Verification

- accessibility tree exposes one selected tab and one named tabpanel
- ArrowRight, ArrowLeft wrapping, Home, End, and click activation each preserved one selected tab, one tab stop, and one visible panel
- all tab and panel relationships resolve in both directions
- desktop and 390px smoke checks loaded 12 escalations with no console warnings or errors
- `node --check event-specific/personal-ai-agents-live-2026-07-21/demo/app/app.js`
- `node scripts/audit-repo.mjs`
- `bash scripts/publication-scan.sh` on an exported tree without worktree metadata
- `git diff --check`

Closes #89
