### PR TITLE
docs: adopt Open Framework Commons v1.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/research-or-curriculum-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/research-or-curriculum-proposal.yml
@@ -56,5 +56,5 @@ body:
       options:
         - label: I did not include secrets, private data, client or attendee records, or sensitive operational details.
           required: true
-        - label: I understand that research or event experience does not amend the AI-Native Operating Framework.
+        - label: I understand that research or event experience does not amend Commons, AI Dev Days governance, or another ecosystem product.
           required: true

--- a/.github/ISSUE_TEMPLATE/workshop-maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/workshop-maintenance.yml
@@ -8,7 +8,7 @@ body:
     id: scope
     attributes:
       label: Scope
-      description: What curriculum, event packet, tool track, setup guide, framework application, or repo workflow needs work?
+      description: What curriculum, event packet, tool track, setup guide, selected-framework teaching alignment, or repo workflow needs work?
       placeholder: Describe the specific repo area and why it needs attention.
     validations:
       required: true
@@ -32,5 +32,5 @@ body:
           required: false
         - label: Changelog should be updated if this changes public material or maintainer workflow.
           required: false
-        - label: Framework claims and event operating guidance should be checked against the canonical AI-Native Operating Framework.
+        - label: Claims about Commons or a selected framework should be checked against that product's canonical source and AI Dev Days' independence boundary.
           required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,12 +18,14 @@
 - [ ] Event-specific assumptions live under `event-specific/`.
 - [ ] Changelog updated when public material or maintainer workflow changed.
 
-## Framework Alignment
+## Commons And Product Boundaries
 
-- [ ] Framework claims link to the canonical
-      `BradGroux/ai-native-operating-framework` repository.
-- [ ] Tool-specific guidance is presented as implementation context, not a
-      framework requirement.
+- [ ] Shared-principle claims link to the adopted Open Framework Commons
+      release rather than duplicating its canonical prose.
+- [ ] Claims about a selected framework link to that product's canonical
+      repository.
+- [ ] Tool and selected-framework guidance is presented as learning context,
+      not an AI Dev Days program requirement.
 - [ ] Event changes make intent, responsibility, work, control, assurance, and
       learning clear in proportion to the event.
 - [ ] Event folders and metadata slugs use `YYYY-MM-DD-<event-slug>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 ## Unreleased
 
+## 1.0.0 - 2026-08-03
+
+- Adopted Open Framework Commons v1.0.0 at release commit
+  `27870fb1d57d951b9ef5a3a86f33ef068ee557da` while preserving AI Dev Days as
+  an independent learning community that owns its curriculum, events,
+  community practices, examples, research, governance, roadmap, and releases.
 - Renamed the repository and program from OpenClaw Dev Days to AI Dev Days
   while preserving OpenClaw as a tool-specific track.
-- Grounded AI Dev Days in the canonical AI-Native Operating Framework,
-  including framework-aligned event planning, verification, shared operating
-  memory, handoff, and post-event learning guidance.
+- Added an AI-Native Operating Framework teaching guide for events or lessons
+  that select that framework, while keeping AI Dev Days' program method and
+  authority product-local.
 - Added a program charter, governance, decision records, contribution SOP,
   Code of Conduct, sensitive-disclosure policy, MIT License, and citation
-  metadata for the version 1.0.0 release candidate.
+  metadata for the version 1.0.0 baseline.
 - Added a canonical research and education method that carries source-grounded
   findings through Understand, Document, Validate, Approve, Use, and Improve.
 - Added a public-source Digital Meld operating-research synthesis with explicit

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,9 +1,9 @@
 # AI Dev Days Charter
 
-**Status:** Version 1.0.0 release candidate; pending founding steward approval  
-**Founding steward:** Brad Groux  
-**Prepared:** 2026-07-30  
-**Effective date:** Upon approval of version 1.0.0
+**Status:** AI Dev Days version 1.0.0<br>
+**Founding steward:** Brad Groux<br>
+**Prepared:** 2026-07-30<br>
+**Effective date:** 2026-08-03
 
 ## Preamble
 
@@ -17,10 +17,9 @@ contributors a place to investigate how people and AI can work together, test
 that understanding in realistic exercises, and preserve what was learned for
 future events.
 
-The
-[AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework)
-is the program's operating foundation. AI Dev Days teaches and applies the
-framework. It does not redefine it.
+AI Dev Days is an independent learning community. It adopts shared ecosystem
+principles without surrendering ownership of its purpose, methods, community,
+or releases.
 
 ## Mission
 
@@ -61,115 +60,60 @@ The program may address:
 
 ## Founding Commitments
 
-### The framework governs operating meaning
+AI Dev Days adopts the shared principles in Open Framework Commons by reference
+and does not restate them as a second canonical list. Its product-local
+commitments are:
 
-AI Dev Days uses the current approved AI-Native Operating Framework as its
-foundation. Framework requirements are linked to their canonical source.
-Educational material, event experience, examples, and tool behavior cannot
-amend the framework implicitly.
+- each event or lesson identifies its learner, purpose, accountable owner,
+  expected outcome, safety boundary, and reviewable evidence;
+- AI may assist with learning and repository work, but humans retain program,
+  event, professional, and acceptance authority;
+- research and event experience remain bounded evidence until an accountable
+  AI Dev Days decision changes curriculum or community practice;
+- public materials use public, licensed, approved, anonymized, or fictional
+  sources and follow the repository's publication-safety rules;
+- events support mixed-skill participation, clear prerequisites, recovery
+  paths, and continued learning; and
+- tools and external frameworks are selected learning contexts, not owners of
+  AI Dev Days' identity or method.
 
-### Start with the people who know the work
+## Open Framework Commons Adoption
 
-Useful AI education begins with the practitioners, recipients, owners, and
-control authorities who understand the real workflow and its exceptions.
-Learners are participants in discovery, not passive recipients of a tool
-demonstration.
+AI Dev Days adopts Open Framework Commons v1.0.0 as its shared philosophical
+foundation:
 
-### Research precedes durable claims
+- **Repository:** [BradGroux/open-framework-commons](https://github.com/BradGroux/open-framework-commons)
+- **Adopted tag:** [`v1.0.0`](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+- **Release commit:** [`27870fb1d57d951b9ef5a3a86f33ef068ee557da`](https://github.com/BradGroux/open-framework-commons/commit/27870fb1d57d951b9ef5a3a86f33ef068ee557da)
 
-Material claims identify their sources, freshness, provenance, limitations,
-and review status. Source facts are separated from analysis and
-recommendations. Raw research has no authority merely because it is stored in
-the repository.
-
-### Business purpose comes before technology
-
-Every exercise or event connects technology to a purpose, accountable owner,
-expected outcome, and boundary. A prompt, model, agent, or platform is not a
-substitute for a business process.
-
-### Human accountability remains explicit
-
-AI may assist with research, drafting, practice, comparison, and verification.
-It does not hold program governance authority, approve its own work, grant
-rights, or replace accountable professional or domain judgment.
-
-### Tools are tracks, not the identity
-
-AI Dev Days remains vendor-neutral at the program level. Tool tracks may use
-OpenClaw, Codex, or other technologies to make the learning concrete. No tool
-defines the program or the framework.
-
-### Evidence matters more than spectacle
-
-The preferred learning outcome is one reviewable artifact, verified result,
-clear decision, or useful handoff. A polished demonstration without evidence,
-ownership, or a continuation path is not sufficient.
-
-### One clear body of material serves people and AI
-
-Documentation should be understandable to every authorized participant. The
-program does not require a parallel curriculum or hidden operating model for
-AI.
-
-### Public learning must be safe to publish
-
-Research and event materials respect privacy, confidentiality, security,
-rights, consent, and professional boundaries. Public examples use public,
-licensed, approved, anonymized, or fictional sources as appropriate.
-
-### Learning must survive the event
-
-Material sources, decisions, current state, evidence, handoffs, feedback, and
-lessons are preserved proportionately so future contributors can verify and
-improve the program. Conversation history alone is not program memory.
-
-### The program must learn
-
-Curriculum and event standards improve through outcomes, evidence, exceptions,
-incidents, facilitator experience, learner feedback, changed sources, and
-changed requirements. Feedback is recorded and dispositioned rather than
-silently folded into current guidance.
-
-### Participation should be practical and inclusive
-
-Materials should support mixed-skill audiences, accessible participation,
-clear prerequisites, recovery paths, and continued learning. Complexity should
-be proportionate to the audience and outcome.
+Commons owns shared principles and boundaries only. AI Dev Days independently
+owns its curriculum, events, community practices, examples, research,
+governance, roadmap, and releases. Adoption does not make AI Dev Days a module,
+child product, framework, or implementation of Commons.
 
 ## Relationship to the AI-Native Operating Framework
 
-The framework defines the business operating framework and method. AI Dev Days
-is a companion research and education initiative that:
-
-- teaches the framework;
-- applies it to educational events and examples;
-- gathers public-safe evidence about how people understand and use it; and
-- may propose improvements through the framework's own contribution process.
-
-AI Dev Days cannot accept or publish a framework change on the framework's
-behalf.
-
-Version 1.0.0 of AI Dev Days is designed against
-[version 1.0.0 of the framework](https://github.com/BradGroux/ai-native-operating-framework/releases/tag/v1.0.0).
-Current framework documents remain authoritative when compatible editorial
-updates are published later.
+AI Dev Days may teach, explore, or apply the AI-Native Operating Framework and
+other ecosystem products. Each selected product remains canonical for its own
+meaning. That teaching relationship does not give another product authority
+over AI Dev Days' local method or decisions.
 
 ## Relationship to Digital Meld
 
-AI Dev Days and the framework are developed within
+AI Dev Days and the AI-Native Operating Framework are independently developed
+within
 [Digital Meld](https://digitalmeld.io)'s research arm. Public Digital Meld
 operating research may inform educational questions, examples, and methods.
 Commercial work, marketing claims, client records, and private operating
-material do not gain educational or framework authority through that
-relationship.
+material do not gain authority over AI Dev Days, Commons, or another ecosystem
+product through that relationship.
 
 AI Dev Days must distinguish:
 
 - public research from private practice;
 - education from consulting or commercial delivery;
 - illustrative examples from validated domain guidance; and
-- program decisions from framework decisions.
+- AI Dev Days decisions from Commons and other ecosystem-product decisions.
 
 ## Non-Goals
 
@@ -192,7 +136,8 @@ Brad Groux is the creator and founding steward of AI Dev Days. Until governance
 expands, the founding steward:
 
 - approves charter and material program changes;
-- protects the boundary with the framework;
+- protects AI Dev Days' independence and its boundary with Commons and other
+  ecosystem products;
 - approves release baselines;
 - appoints or confirms maintainers;
 - records material decisions, dissent, limitations, and unresolved risks; and
@@ -221,7 +166,7 @@ A material charter amendment requires:
 
 1. a written proposal describing the need, evidence, alternatives, and
    consequences;
-2. review against the current framework and this charter's commitments;
+2. review against the adopted Commons release and this charter's commitments;
 3. a documented decision by the founding steward or future governing body;
 4. publication of material dissent, limitations, and unresolved risk;
 5. updates to affected governance, methods, curriculum, and event guidance; and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,10 +9,11 @@ repository-code: "https://github.com/BradGroux/ai-dev-days"
 url: "https://github.com/BradGroux/ai-dev-days"
 license: MIT
 version: 1.0.0
+date-released: 2026-08-03
 abstract: >-
-  A public research and education companion to the AI-Native Operating
-  Framework, with reusable curriculum, events, labs, tool tracks, and evidence
-  for learning how people and AI perform work together.
+  An independent learning community and event repository that adopts Open
+  Framework Commons v1.0.0, with reusable curriculum, events, labs, tool
+  tracks, and evidence for learning how people and AI perform work together.
 keywords:
   - artificial intelligence
   - AI literacy

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,10 +3,14 @@
 This context defines event and curriculum terms that have specific meaning in
 AI Dev Days materials.
 
-The
-[AI-Native Operating Framework glossary](https://github.com/BradGroux/ai-native-operating-framework/blob/v1.0.0/framework/glossary.md)
-governs framework terminology. Local terms below describe educational or
-tool-specific implementation context and do not amend the framework.
+The adopted
+[Open Framework Commons v1.0.0 context](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/CONTEXT.md)
+defines shared ecosystem terms. Local terms below describe AI Dev Days
+educational or tool-specific context and do not amend Commons or another
+ecosystem product.
+
+When material teaches a named framework, that framework's glossary governs
+representations of its own terminology only.
 
 ## Language
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # SOP: Contributing to AI Dev Days
 
-**Status:** Version 1.0.0 release candidate<br>
+**Status:** Version 1.0.0<br>
 **Accountable owner:** Founding steward or future governing body<br>
 **Process manager:** Program maintainer<br>
 **Prepared:** 2026-07-30<br>
-**Review triggers:** Program release, framework compatibility change,
+**Review triggers:** Program release, Commons adoption change,
 governance change, repeated contribution problem, disputed decision,
 publication-safety incident, accessibility finding, or recurring tool drift
 
@@ -46,7 +46,8 @@ The expected outcome is a contribution that:
 
 - addresses a clear learner, facilitator, researcher, or maintainer need;
 - is classified according to its effect;
-- respects the AI-Native Operating Framework boundary;
+- respects the adopted Open Framework Commons boundary and AI Dev Days'
+  independence;
 - states sources, evidence, rights, assistance, limitations, and uncertainty
   honestly;
 - is reviewed proportionately;
@@ -145,23 +146,25 @@ Prefer primary and authoritative sources. A substantive note records:
 - sources and capture dates;
 - source facts separated from analysis;
 - provenance, freshness, drift risk, conflicts, and uncertainty;
-- relevance to the framework and program;
+- relevance to Commons, any selected ecosystem product, and AI Dev Days;
 - what should and should not be reused;
 - rights, attribution, consent, and publication limits;
 - remaining gaps and review needs; and
 - a recommended disposition.
 
-Framework claims cite the canonical
-[AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework).
-Research may inform a proposal but cannot amend the framework or program
-silently.
+Claims about shared ecosystem principles cite the adopted
+[Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0).
+Claims about a specific framework cite that framework's canonical source.
+Research may inform a proposal but cannot amend Commons, another product, or
+AI Dev Days silently.
 
 ## 6. Draft the Smallest Complete Change
 
 The draft:
 
 - follows [`CHARTER.md`](CHARTER.md), accepted
-  [decisions](decisions/README.md), and current framework language;
+  [decisions](decisions/README.md), the adopted Commons release, and current
+  product-local guidance;
 - keeps program-level learning vendor-neutral;
 - treats OpenClaw, Codex, and other technologies as tool tracks;
 - states learner, purpose, owner, outcome, boundary, and evidence;
@@ -184,7 +187,8 @@ and status must be honest.
 
 Check:
 
-- charter, governance, framework, and accepted-decision alignment;
+- charter, governance, Commons, product independence, and accepted-decision
+  alignment;
 - research provenance and claim-to-source traceability;
 - the intended learner, prerequisite, outcome, exercise, and evidence;
 - normal, exception, and credible failure or recovery paths;
@@ -250,7 +254,7 @@ The pull request states:
 
 - the problem and contribution class;
 - what changed;
-- sources and framework effect;
+- sources and Commons or product-boundary effect;
 - how learning or event behavior changes;
 - verification performed;
 - public, accessibility, domain, or tool-drift risks;
@@ -290,7 +294,8 @@ After use:
 Stop integration, event use, or release when:
 
 - the responsible authority has not approved a material change;
-- the contribution conflicts with the charter or framework boundary;
+- the contribution conflicts with the charter, adopted Commons boundary, or
+  an explicitly selected framework's own meaning;
 - sources, rights, attribution, consent, or licensing remain unresolved;
 - private, personal, confidential, unsafe, or security-sensitive material may
   remain;

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,15 +1,15 @@
 # AI Dev Days Governance
 
-**Status:** Version 1.0.0 release candidate; pending founding steward approval  
-**Founding steward:** Brad Groux  
+**Status:** AI Dev Days version 1.0.0<br>
+**Founding steward:** Brad Groux<br>
 **Prepared:** 2026-07-30
 
 ## Purpose
 
 This document governs how AI Dev Days turns research and event experience into
 maintained education without allowing a source note, tool track, event packet,
-commercial practice, or AI-generated draft to redefine the program or the
-AI-Native Operating Framework silently.
+commercial practice, or AI-generated draft to redefine the program, Commons,
+or another ecosystem product silently.
 
 ## Authority
 
@@ -19,18 +19,22 @@ Apply this order when program materials conflict:
    body.
 2. [`CHARTER.md`](CHARTER.md).
 3. Accepted records under [`decisions/`](decisions/README.md).
-4. The canonical
+4. The adopted
+   [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+   for shared ecosystem principles and boundaries.
+5. The canonical
    [research and education method](docs/research-and-education-method.md).
-5. This governance document and [`CONTRIBUTING.md`](CONTRIBUTING.md).
-6. Approved curriculum and reusable program standards.
-7. Event packets and examples.
-8. Tool-track instructions.
-9. Research notes, planning records, and history.
+6. This governance document and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+7. Approved curriculum and reusable program standards.
+8. Event packets and examples.
+9. Tool-track instructions.
+10. Research notes, planning records, and history.
 
-The
-[AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework)
-governs every framework term or claim regardless of this local order. AI Dev
-Days cannot approve a framework change.
+Commons does not own AI Dev Days' local decisions, and changes to Commons do
+not alter the adopted `v1.0.0` baseline automatically. If local guidance
+appears to conflict with Commons, stop and surface the conflict. A named
+framework remains canonical only for representations of its own method; AI Dev
+Days cannot approve a change on that product's behalf.
 
 ## Current Stewardship
 
@@ -38,7 +42,7 @@ Brad Groux is the creator and founding steward. Until governance expands, the
 founding steward:
 
 - approves charter amendments and material program decisions;
-- protects the program's framework-companion boundary;
+- protects the program's independence and adopted Commons boundary;
 - approves versioned release baselines;
 - delegates curriculum, research, event, tool-track, or repository
   maintenance;
@@ -48,7 +52,7 @@ founding steward:
 The program is developed within
 [Digital Meld](https://digitalmeld.io)'s research arm. That relationship does
 not grant Digital Meld commercial material, client work, or marketing content
-authority over the framework or this program.
+authority over Commons, another ecosystem product, or this program.
 
 ## Roles
 
@@ -106,7 +110,7 @@ substitute for accountable domain review.
 | Class | Typical effect | Required path |
 | --- | --- | --- |
 | Charter amendment | Mission, commitments, scope, stewardship, or amendment rules | Written proposal and founding steward or governing-body approval |
-| Material program decision | Framework relationship, research or education method, authority, release policy, or program identity | Decision record and accountable approval |
+| Material program decision | Commons adoption, ecosystem-product relationship, research or education method, authority, release policy, or program identity | Decision record and accountable approval |
 | Governance change | Roles, decision authority, appeals, contribution, or release approval | Written governance decision |
 | Research record | Source-grounded facts, analysis, gaps, or recommendation | Research review; no automatic program effect |
 | Curriculum change | Reusable learning objective, lab, facilitator standard, or assessment | Curriculum review and proportionate validation |
@@ -160,7 +164,7 @@ Every substantive research note states:
 - source facts separated from analysis and recommendations;
 - provenance, freshness, uncertainty, and conflicting evidence;
 - rights, reuse, privacy, and publication limits;
-- relevance to the framework and program;
+- relevance to Commons, any selected ecosystem product, and AI Dev Days;
 - what should and should not be reused;
 - remaining gaps and required review; and
 - a proposed disposition.
@@ -209,7 +213,8 @@ An approved release identifies:
 
 - version and exact repository tag;
 - effective date;
-- framework compatibility baseline;
+- adopted Commons version and exact release commit;
+- any product-specific teaching compatibility baseline;
 - material changes;
 - known limitations and review status;
 - superseded versions;
@@ -231,12 +236,18 @@ Before release:
 7. obtain explicit release approval; and
 8. create an annotated tag and GitHub release from the approved commit.
 
-### Prepared Version 1.0.0 Baseline
+### Approved AI Dev Days Version 1.0.0 Baseline
 
-- **Version:** 1.0.0 release candidate
-- **Framework compatibility:** AI-Native Operating Framework 1.0.0
+- **Version:** 1.0.0
+- **Commons adoption:** Open Framework Commons v1.0.0 at
+  `27870fb1d57d951b9ef5a3a86f33ef068ee557da`
+- **Product-specific teaching baseline:** AI-Native Operating Framework 1.0.0
+  where a lesson or event selects it
 - **Prepared date:** 2026-07-30
-- **Repository tag:** `v1.0.0`, not yet authorized
+- **Repository tag:** `v1.0.0`
+- **Release authorization:** approved by the founding steward on 2026-08-03,
+  conditional on the reviewed migration being merged and the merged tree being
+  verified
 - **Superseded public version:** none
 - **Responsible steward:** Brad Groux
 - **Known limitations:** event outcomes have not yet been measured under the
@@ -267,7 +278,7 @@ governance limitation must be stated.
 Review this document when:
 
 - participation or event scale changes materially;
-- the framework publishes a potentially incompatible release;
+- Commons publishes a potentially incompatible release;
 - decision or maintenance authority changes;
 - research repeatedly fails to reach a clear disposition;
 - learners or contributors cannot identify current guidance;

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,9 +3,13 @@
 On July 30, 2026, `BradGroux/openclaw-dev-days` was renamed to
 `BradGroux/ai-dev-days`.
 
-The repository evolved beyond one tool. AI Dev Days now uses the
-[AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework)
-as its operating foundation while retaining OpenClaw as a tool-specific track.
+The repository evolved beyond one tool while retaining OpenClaw as a
+tool-specific track. The original migration described AI Dev Days as a
+companion to the AI-Native Operating Framework. That relationship was
+superseded by
+[ADR-002](decisions/0002-adopt-open-framework-commons-v1.0.0.md), which adopts
+Open Framework Commons v1.0.0 and preserves AI Dev Days as an independent
+learning community.
 
 ## Repository URL
 
@@ -55,8 +59,11 @@ Historical event names remain unchanged where they describe an event that was
 actually presented under the OpenClaw Dev Days name. Current program,
 repository, and navigation references use AI Dev Days.
 
-The canonical relationship is:
+The current relationship is:
 
-- the AI-Native Operating Framework defines the framework;
-- AI Dev Days teaches and applies it; and
+- Open Framework Commons v1.0.0 supplies shared principles and boundaries;
+- AI Dev Days owns its learning community, methods, curriculum, events,
+  governance, and releases;
+- AI Dev Days may teach or apply the AI-Native Operating Framework without
+  inheriting its method or becoming its training module; and
 - OpenClaw, Codex, and other tools provide implementation contexts.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,24 @@
 > `git remote set-url origin https://github.com/BradGroux/ai-dev-days.git`.
 > See [`MIGRATION.md`](MIGRATION.md) for the event-folder path changes.
 
-AI Dev Days is the public research and education companion to the AI-Native
-Operating Framework. It helps people investigate, define, perform, verify, and
-improve useful work with AI.
+AI Dev Days is an independent learning community and event repository. It helps
+people investigate, define, perform, verify, and improve useful work with AI.
+
+AI Dev Days adopts
+[Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+as its shared philosophical foundation. The adopted release is pinned to:
+
+- repository: [BradGroux/open-framework-commons](https://github.com/BradGroux/open-framework-commons)
+- tag: [`v1.0.0`](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+- release commit: [`27870fb1d57d951b9ef5a3a86f33ef068ee557da`](https://github.com/BradGroux/open-framework-commons/commit/27870fb1d57d951b9ef5a3a86f33ef068ee557da)
+
+Commons supplies shared principles and boundaries; it is not a parent product
+or operating method. AI Dev Days independently owns its curriculum, events,
+community practices, examples, research, governance, roadmap, and releases.
 
 The [AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework)
-is the program's operating foundation. It keeps business purpose, human
-accountability, controls, evidence, shared operating memory, and learning ahead
-of any particular technology. AI Dev Days teaches and applies the framework; it
-does not redefine it.
+is one ecosystem product AI Dev Days may teach or apply. Its methods govern
+representations of that framework, not AI Dev Days as a whole.
 
 OpenClaw is the deepest existing tool-specific track in this repository.
 Codex and other tools also appear in event material. Tools provide the
@@ -36,8 +45,11 @@ Start with [`START-HERE.md`](START-HERE.md) if you are not sure which file you n
 - Facilitators: use [`RUNBOOK.md`](RUNBOOK.md).
 - Organizers: copy [`event-specific/_template/`](event-specific/_template/) for a new event.
 - Curriculum: use [`curriculum/README.md`](curriculum/README.md) and [`curriculum/course-map.md`](curriculum/course-map.md).
-- Operating foundation: use
-  [`docs/ai-native-operating-framework-alignment.md`](docs/ai-native-operating-framework-alignment.md).
+- Shared foundation and independence: use [`CHARTER.md`](CHARTER.md) and the
+  adopted [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0).
+- AI-Native Operating Framework teaching guide: use
+  [`docs/ai-native-operating-framework-alignment.md`](docs/ai-native-operating-framework-alignment.md)
+  when an event or lesson selects that framework.
 - Program charter and authority: use [`CHARTER.md`](CHARTER.md) and
   [`GOVERNANCE.md`](GOVERNANCE.md).
 - Research and education method: use
@@ -141,7 +153,8 @@ the source citation and workshop mapping.
 ## Core stance
 
 - **First success beats feature coverage.** If people don’t get a working loop early, the rest doesn’t matter.
-- **Business purpose comes before technology.** The tool is part of the operating environment, not the framework.
+- **Business purpose comes before technology.** A tool is learning context, not
+  the program identity or method.
 - **One standard serves people and AI.** Clear operating documentation should work for every authorized participant.
 - **Scenario-first beats blank slate.** Give people a concrete use case instead of a vague platform tour.
 - **Evidence beats activity.** A completed exercise should leave a reviewable result, not only a demo.
@@ -158,13 +171,13 @@ the source citation and workshop mapping.
 - `labs/` — attendee exercises with binary success checkpoints, including the Markdown thinking-layer lab
 - `helper-runbook/` — facilitator triage and rescue-lane guidance
 - `troubleshooting/` — tool, model, provider, and workshop recovery guidance
-- `docs/` — framework alignment, reusable explainers, and visual reference material
+- `docs/` — product-local methods, optional framework teaching guides, reusable explainers, and visual reference material
 - `CHARTER.md` and `GOVERNANCE.md` — program purpose, authority, decisions, and release rules
 - `decisions/` — material program decisions and their rationale
 - `docs/research-and-education-method.md` — canonical program method
 - `docs/ai-native-operating-framework-alignment.md` — authoritative relationship and event-application guidance
 - `docs/ai-literacy-framework-alignment.md` — mapping to the U.S. Department of Labor AI Literacy Framework
-- `event-specific/` — date-first event packets plus a framework-aligned reusable template
+- `event-specific/` — date-first event packets plus an AI Dev Days-owned reusable template
 - `research/` — source-grounded notes and dispositions; not attendee instructions
 - `scripts/` — lightweight repo maintenance and publication safety checks
 - `CONTRIBUTING.md` — contributor workflow, verification, and review checklist
@@ -173,7 +186,8 @@ the source citation and workshop mapping.
 ## Current refinement priorities
 
 1. Keep current and upcoming event packets ready to run from the README.
-2. Apply the AI-Native Operating Framework proportionately to each event.
+2. Keep AI Dev Days guidance product-local and use external frameworks only
+   when an event or lesson selects them explicitly.
 3. Keep first-success paths short and specific to the selected tool track.
 4. Keep each event packet public-safe, source-backed, and easy to audit.
 5. Preserve useful evidence, decisions, handoffs, and lessons after each event.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -10,8 +10,10 @@ Use this as the one-page control panel for running an AI Dev Days session.
 3. Start from [the event template](event-specific/_template/README.md) if this is a new workshop.
 4. Confirm attendee requirements, setup guides, agenda, verification evidence,
    handoffs, and helper lanes are linked from the event folder.
-5. Review the
-   [AI-Native Operating Framework alignment](docs/ai-native-operating-framework-alignment.md).
+5. Review the [AI Dev Days Charter](CHARTER.md), including the adopted Commons
+   release and product-independence boundary. If the event teaches or applies
+   the AI-Native Operating Framework, also review the
+   [product-local teaching guide](docs/ai-native-operating-framework-alignment.md).
 6. Review the
    [research and education method](docs/research-and-education-method.md);
    confirm material claims, the learner outcome, and the reviewable evidence.
@@ -33,7 +35,9 @@ Have these open before attendees arrive:
 
 - event attendee links
 - event agenda
-- [AI-Native Operating Framework alignment](docs/ai-native-operating-framework-alignment.md)
+- [AI Dev Days Charter and Commons adoption](CHARTER.md)
+- [AI-Native Operating Framework teaching guide](docs/ai-native-operating-framework-alignment.md),
+  when selected by the event
 - [Research and education method](docs/research-and-education-method.md)
 - [AI Literacy Framework alignment](docs/ai-literacy-framework-alignment.md)
 - [Event refresh checklist](event-specific/refresh-checklist.md)

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -2,18 +2,20 @@
 
 Use this page to choose the shortest useful path through the repo.
 
-## I want to understand the operating foundation
+## I want to understand the shared foundation
 
 Start with:
 
 1. [AI Dev Days Charter](CHARTER.md)
-2. [AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework)
-3. [AI Dev Days framework alignment](docs/ai-native-operating-framework-alignment.md)
+2. [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+3. [Governance](GOVERNANCE.md)
 4. [Research and education method](docs/research-and-education-method.md)
-5. [Governance](GOVERNANCE.md)
-6. [Curriculum overview](curriculum/README.md)
-7. [Facilitator runbook](RUNBOOK.md)
-8. [Event template](event-specific/_template/README.md)
+5. [Curriculum overview](curriculum/README.md)
+6. [Facilitator runbook](RUNBOOK.md)
+7. [Event template](event-specific/_template/README.md)
+
+For an event or lesson that selects the AI-Native Operating Framework, use the
+[product-local teaching guide](docs/ai-native-operating-framework-alignment.md).
 
 ## I want to research or contribute
 

--- a/curriculum/README.md
+++ b/curriculum/README.md
@@ -2,10 +2,12 @@
 
 This folder contains the reusable teaching path for AI Dev Days.
 
-The
-[AI-Native Operating Framework](../docs/ai-native-operating-framework-alignment.md)
-is the operating foundation. The curriculum applies it through practical
-events, tool tracks, reviewable work, and public learning.
+AI Dev Days adopts
+[Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+as its shared philosophical foundation while owning this curriculum and its
+learning method independently. An event or lesson may select the
+[AI-Native Operating Framework teaching alignment](../docs/ai-native-operating-framework-alignment.md)
+without making that framework the program's parent or required method.
 
 The
 [AI Dev Days research and education method](../docs/research-and-education-method.md)
@@ -32,7 +34,7 @@ learning, enabling roles, and agility.
 
 - [Course map](course-map.md)
 - [One-day agenda](agenda/ai-dev-days-one-day.md)
-- [AI-Native Operating Framework alignment](../docs/ai-native-operating-framework-alignment.md)
+- [AI-Native Operating Framework teaching alignment](../docs/ai-native-operating-framework-alignment.md)
 - [Research and education method](../docs/research-and-education-method.md)
 - [AI Literacy Framework alignment](../docs/ai-literacy-framework-alignment.md)
 - [Markdown thinking layer](modules/markdown-thinking-layer.md)

--- a/curriculum/agenda/ai-dev-days-one-day.md
+++ b/curriculum/agenda/ai-dev-days-one-day.md
@@ -4,7 +4,9 @@
 
 **Length:** 6-8 hours  
 **Style:** hands-on workshop  
-**Operating foundation:** AI-Native Operating Framework
+**Shared foundation:** Open Framework Commons v1.0.0
+
+**Selected teaching alignment:** AI-Native Operating Framework 1.0.0
 
 **Reference tool track:** OpenClaw
 
@@ -23,7 +25,7 @@
 - Evidence, handoff, and learning are part of completion.
 - AI literacy means understanding, directing, evaluating, and responsibly using AI in context.
 
-Source alignment:
+Selected teaching alignment:
 [AI-Native Operating Framework](../../docs/ai-native-operating-framework-alignment.md)
 and
 [U.S. Department of Labor AI Literacy Framework](../../docs/ai-literacy-framework-alignment.md).

--- a/curriculum/course-map.md
+++ b/curriculum/course-map.md
@@ -17,10 +17,11 @@ The subject is not "prompting tricks." The subject is operator skill:
 - improve the work from outcomes and lessons
 - decide what ships
 
-The
-[AI-Native Operating Framework](../docs/ai-native-operating-framework-alignment.md)
-is the operating foundation. OpenClaw is the current reference tool track, not
-a framework requirement.
+AI Dev Days owns this course map. Its shared philosophical foundation is
+[Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0).
+The [AI-Native Operating Framework teaching alignment](../docs/ai-native-operating-framework-alignment.md)
+is available when a lesson selects that framework. OpenClaw is the current
+reference tool track, not a program or framework requirement.
 
 The
 [research and education method](../docs/research-and-education-method.md)

--- a/decisions/0001-framework-companion-for-research-and-education.md
+++ b/decisions/0001-framework-companion-for-research-and-education.md
@@ -1,7 +1,8 @@
 # ADR-001: Framework Companion for Research and Education
 
-- **Status:** accepted for the version 1.0.0 release candidate; pending founding
-  steward release approval
+- **Status:** superseded by
+  [ADR-002](0002-adopt-open-framework-commons-v1.0.0.md) on 2026-08-03;
+  retained as historical context
 - **Date:** 2026-07-30
 - **Owner:** Brad Groux
 

--- a/decisions/0002-adopt-open-framework-commons-v1.0.0.md
+++ b/decisions/0002-adopt-open-framework-commons-v1.0.0.md
@@ -1,0 +1,96 @@
+# ADR-002: Adopt Open Framework Commons v1.0.0 and Preserve Product Independence
+
+- **Status:** accepted
+- **Date:** 2026-08-03
+- **Owner:** Brad Groux
+
+## Question
+
+How should AI Dev Days participate in the Open Framework Ecosystem without
+becoming another operating framework or inheriting another product's method,
+structure, governance, or release process?
+
+## Context and Evidence
+
+AI Dev Days already has its own learning-community purpose, curriculum, event
+operations, research and education method, examples, publication controls,
+governance, and prepared release process.
+
+Open Framework Commons v1.0.0 defines shared principles and boundaries for the
+ecosystem while stating that AI Dev Days is an independent learning community.
+Its annotated `v1.0.0` tag resolves to release commit
+`27870fb1d57d951b9ef5a3a86f33ef068ee557da`.
+
+ADR-001 described AI Dev Days as the companion to, and operationally grounded
+in, the AI-Native Operating Framework. That hierarchy conflicts with the
+Commons product-independence boundary.
+
+## Alternatives Considered
+
+### Keep the framework-companion hierarchy
+
+This preserves existing wording but makes another product appear to govern AI
+Dev Days and risks treating that product's method as inherited program policy.
+
+### Copy Commons principles into AI Dev Days
+
+This would create duplicated shared prose that could drift from the adopted
+Commons release.
+
+### Adopt Commons by reference and keep AI Dev Days product-local
+
+This provides a stable shared foundation while preserving AI Dev Days'
+independent purpose, authority, content, and evolution.
+
+## Decision
+
+AI Dev Days adopts
+[Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+at release commit
+[`27870fb1d57d951b9ef5a3a86f33ef068ee557da`](https://github.com/BradGroux/open-framework-commons/commit/27870fb1d57d951b9ef5a3a86f33ef068ee557da).
+
+- Commons shared principles and boundaries are adopted by reference.
+- AI Dev Days remains an independent learning community and event repository.
+- AI Dev Days owns its curriculum, events, community practices, examples,
+  research, governance, roadmap, and releases.
+- AI Dev Days may teach or explore another ecosystem product without becoming
+  its training module or inheriting its method.
+- No Commons software, schema, runtime, conformance, CI, validator, or shared
+  repository structure is introduced.
+- ADR-001 is superseded.
+
+## Consequences
+
+Public entry points pin the adopted Commons repository, tag, and commit.
+Product-local documents retain their distinct reader jobs. Existing
+AI-Native Operating Framework material remains available as a teaching guide
+for events or lessons that explicitly select it.
+
+The existing charter, governance, Code of Conduct, security policy, and license
+remain AI Dev Days-owned. No duplicate foundation document is added.
+
+## Dissent and Uncertainty
+
+No deviation from the Commons v1.0.0 shared principles is recorded.
+
+The founding steward authorized publishing AI Dev Days `v1.0.0` on 2026-08-03
+after the migration is merged and the merged tree is verified. The tag must be
+new and immutable; no published tag may be moved.
+
+## Affected Artifacts
+
+- `README.md`
+- `START-HERE.md`
+- `CHARTER.md`
+- `GOVERNANCE.md`
+- `CONTRIBUTING.md`
+- `CHANGELOG.md`
+- product-local curriculum, event, research, and release entry points that
+  described another product as AI Dev Days' operating foundation
+
+## Sources
+
+- [Open Framework Commons repository](https://github.com/BradGroux/open-framework-commons)
+- [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+- [Open Framework Commons v1.0.0 boundaries](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/BOUNDARIES.md)
+- [Open Framework Commons v1.0.0 governance](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/GOVERNANCE.md)

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -4,19 +4,23 @@ Material AI Dev Days decisions are recorded here so program meaning does not
 change silently through research notes, event packets, tool tracks, or repeated
 practice.
 
-## Accepted for the Version 1.0.0 Release Candidate
+## Program Decisions
 
 1. [ADR-001: Framework companion for research and education](0001-framework-companion-for-research-and-education.md)
+   — superseded by ADR-002
+2. [ADR-002: Adopt Open Framework Commons v1.0.0 and preserve product independence](0002-adopt-open-framework-commons-v1.0.0.md)
+   — accepted
 
-These decisions remain release-candidate decisions until the founding steward
-approves the version 1.0.0 baseline.
+Program decisions take effect independently of whether an AI Dev Days release
+tag has been published. Release publication still follows the separate release
+approval process.
 
 ## Guidance
 
 Create a decision record for a material, difficult-to-reverse program decision
 with real alternatives and consequences. Examples include:
 
-- the program's relationship to the AI-Native Operating Framework;
+- Commons adoption or the program's relationship to another ecosystem product;
 - research or education authority and method;
 - program identity and vendor neutrality;
 - governance, contribution, or release authority; and

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,16 @@
 # Docs
 
-Operating alignment, reusable explainers, and visual reference material for AI
-Dev Days.
+Product-local methods, optional teaching alignments, reusable explainers, and
+visual reference material for AI Dev Days.
 
-## Operating foundation
+## Shared foundation
 
-- [AI-Native Operating Framework alignment](ai-native-operating-framework-alignment.md)
+- [AI Dev Days Charter](../CHARTER.md)
+- [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+
+## Product-local methods and teaching alignments
+
+- [AI-Native Operating Framework teaching alignment](ai-native-operating-framework-alignment.md)
 - [AI Dev Days research and education method](research-and-education-method.md)
 - [AI Literacy Framework alignment](ai-literacy-framework-alignment.md)
 
@@ -25,8 +30,8 @@ The [program charter](../CHARTER.md), [governance](../GOVERNANCE.md), and
 
 Use the Markdown explainer for facilitator notes, attendee reading, and repo documentation. Use the HTML page when you want a visual walk-through in a browser or presentation.
 
-Use the operating-framework alignment when designing, approving, running, or
-improving an event. Use the AI literacy alignment when describing how the
+Use the AI-Native teaching alignment only when an event or lesson selects that
+framework. Use the AI literacy alignment when describing how the
 curriculum maps to the U.S. Department of Labor's AI Literacy Framework.
 Use the research and education method when investigating sources, turning
 findings into curriculum, validating learning, and dispositioning event

--- a/docs/ai-native-operating-framework-alignment.md
+++ b/docs/ai-native-operating-framework-alignment.md
@@ -1,22 +1,26 @@
-# AI-Native Operating Framework Alignment
+# AI-Native Operating Framework Teaching Alignment
 
-AI Dev Days uses the
+AI Dev Days is an independent learning community that adopts
+[Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0).
+This product-local guide applies only when an event or lesson selects the
 [AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework)
-as its operating foundation.
+as subject matter or a practical method to explore.
 
-The framework is canonical. This repository contains educational material and
-event applications. Nothing in AI Dev Days amends, extends, or overrides the
-framework.
+The framework is canonical for its own meaning. AI Dev Days owns the learning
+design, event application, examples, and decisions around how or whether to
+teach it. Nothing in AI Dev Days amends, extends, or overrides the framework,
+and the framework does not govern AI Dev Days as a whole.
 
-AI Dev Days version 1.0.0 is designed against the
+This teaching guide is designed against the
 [AI-Native Operating Framework 1.0.0 release](https://github.com/BradGroux/ai-native-operating-framework/releases/tag/v1.0.0).
 Tagged links below provide a stable compatibility baseline. The current
-framework repository remains authoritative for later approved corrections and
-releases.
+framework repository may contain later releases, but they do not change this
+guide's pinned baseline automatically.
 
 ## Canonical Sources
 
-Use the current framework repository rather than copying its documents here:
+When teaching this framework, link to its canonical documents rather than
+copying them here:
 
 1. [Charter](https://github.com/BradGroux/ai-native-operating-framework/blob/v1.0.0/framework/charter.md)
 2. [Operating framework](https://github.com/BradGroux/ai-native-operating-framework/blob/v1.0.0/framework/operating-framework.md)
@@ -25,15 +29,17 @@ Use the current framework repository rather than copying its documents here:
 5. [Standards maintenance method](https://github.com/BradGroux/ai-native-operating-framework/blob/v1.0.0/framework/standards-maintenance-method.md)
 6. [Glossary](https://github.com/BradGroux/ai-native-operating-framework/blob/v1.0.0/framework/glossary.md)
 
-If this repository conflicts with a canonical framework document, the
-framework document governs.
+If AI Dev Days misstates the framework, the framework document governs the
+correction of that representation. AI Dev Days' charter and governance still
+govern the learning community and event repository.
 
 ## Relationship
 
 | Body | Responsibility | Authority |
 | --- | --- | --- |
-| AI-Native Operating Framework | Defines the open business operating framework and method | Canonical |
-| AI Dev Days | Researches, teaches, applies, and learns through public education | Companion program |
+| Open Framework Commons | Defines adopted shared ecosystem principles and boundaries | Shared foundation at the adopted tag |
+| AI Dev Days | Owns its learning community, curriculum, events, examples, governance, and releases | Independent product |
+| AI-Native Operating Framework | Defines its own open business operating framework and method | Canonical for its own meaning |
 | AI Dev Days research | Supplies bounded source facts, analysis, and proposals | Evidence only until dispositioned |
 | Reusable curriculum | Defines approved program learning material | Program-level educational guidance |
 | Event packets | Adapt the program to a specific audience, outcome, and operating context | Event-specific |
@@ -42,9 +48,10 @@ framework document governs.
 The framework is vendor-neutral. OpenClaw is the most developed tool track in
 this repository, but no tool defines AI Dev Days or the framework.
 
-## Event Application
+## Event Application When Selected
 
-Each event applies the framework's six business concerns proportionately:
+An event that explicitly selects this framework may apply its six business
+concerns proportionately:
 
 | Concern | Event material should make clear |
 | --- | --- |
@@ -55,12 +62,14 @@ Each event applies the framework's six business concerns proportionately:
 | Assurance | Completion criteria, checks, evidence, reviewers, and authoritative results |
 | Learning | Maintainer, feedback, outcomes, lessons, review triggers, and approved improvements |
 
-These concerns are not mandatory agenda phases or document headings. Event
-material may use any clear structure that communicates the required meaning.
+These concerns are not Commons requirements or mandatory AI Dev Days agenda
+phases. The event owner decides whether this mapping serves the audience and
+outcome.
 
 ## Event Maintenance
 
-Use the framework's standards maintenance method as a practical event loop:
+For an event that teaches this framework, its standards maintenance method can
+be mapped to the AI Dev Days event lifecycle:
 
 1. **Understand:** confirm the audience, business need, owners, sources,
    constraints, risks, and unresolved questions.
@@ -75,15 +84,15 @@ Use the framework's standards maintenance method as a practical event loop:
 6. **Improve:** review outcomes, exceptions, feedback, and evidence; record
    approved changes for future events.
 
-The complete research-to-education application, including source standards,
+The AI Dev Days-owned research-to-education method, including source standards,
 research disposition, curriculum validation, event evidence, and program
 measures, is maintained in the
 [AI Dev Days research and education method](research-and-education-method.md).
 
 ## Shared Operating Memory
 
-Event work should preserve only the durable context needed to continue,
-verify, and improve the program:
+When this teaching alignment is used, event work should preserve only the
+durable context needed to continue, verify, and improve the learning:
 
 - identifiable sources and provenance for material claims;
 - approved purpose, scope, audience, and decisions;
@@ -103,7 +112,7 @@ repository.
 
 ## Event Readiness Check
 
-Before an event is approved for use, confirm:
+Before an event using this teaching alignment is approved, confirm:
 
 - the outcome and accountable owner are explicit;
 - tool choices follow the event need rather than defining it;

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,11 +10,13 @@ approve an official release after reviewing the final candidate and audit.
 
 ## Prepare
 
-1. Confirm the intended version and framework compatibility baseline.
+1. Confirm the intended version, adopted Commons tag and commit, and any
+   product-specific teaching compatibility baseline.
 2. Update [`CHANGELOG.md`](../CHANGELOG.md).
 3. Prepare the release notes under [`docs/releases/`](releases/).
-4. Confirm charter, governance, decisions, research, curriculum, events, tool
-   tracks, citation metadata, and migration guidance are consistent.
+4. Confirm charter, governance, Commons adoption, decisions, research,
+   curriculum, events, tool tracks, citation metadata, and migration guidance
+   are consistent.
 5. Confirm known limitations and unavailable reviews are visible.
 
 ## Validate

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,17 +1,21 @@
-# AI Dev Days 1.0.0 Release Candidate
+# AI Dev Days 1.0.0
 
-**Status:** Pending final audit and founding steward approval  
-**Framework compatibility:** AI-Native Operating Framework 1.0.0  
-**Prepared:** 2026-07-30  
-**Proposed tag:** `v1.0.0`
+**Status:** Approved initial release<br>
+**Commons adoption:** Open Framework Commons v1.0.0 at `27870fb1d57d951b9ef5a3a86f33ef068ee557da`<br>
+**Teaching compatibility:** AI-Native Operating Framework 1.0.0 when selected<br>
+**Prepared:** 2026-07-30<br>
+**Approved:** 2026-08-03<br>
+**Released:** 2026-08-03<br>
+**Tag:** `v1.0.0`
 
 ## Summary
 
-AI Dev Days 1.0.0 establishes the project as the public research and education
-companion to the AI-Native Operating Framework.
+AI Dev Days 1.0.0 establishes the project as an independent learning community
+and event repository that adopts Open Framework Commons v1.0.0 by reference.
 
-The release preserves OpenClaw as the most developed tool track while making
-the program vendor-neutral. It also changes the repository name from
+The release preserves OpenClaw as the most developed tool track, keeps the
+AI-Native Operating Framework available as optional teaching material, and
+keeps the program vendor-neutral. It also changes the repository name from
 `openclaw-dev-days` to `ai-dev-days` and moves dated event folders to a
 date-first convention.
 
@@ -19,20 +23,25 @@ date-first convention.
 
 - Program charter, governance, decision records, contribution SOP, Code of
   Conduct, sensitive-disclosure policy, MIT License, and citation metadata.
-- A framework-aligned research and education method based on Understand,
+- An AI Dev Days-owned research and education method based on Understand,
   Document, Validate, Approve, Use, and Improve.
 - Source-grounded Digital Meld operating-research synthesis with explicit reuse
   limits.
-- Framework alignment for curriculum, events, evidence, shared operating
-  memory, and post-event learning.
+- Product-local curriculum, event, evidence, shared-memory, and post-event
+  learning guidance, plus an optional AI-Native Operating Framework teaching
+  alignment.
+- Open Framework Commons v1.0.0 adoption with an explicit product-independence
+  boundary.
 - Release process with an explicit owner approval gate.
 - Date-first event-folder validation and migration guidance.
-- Framework-aligned event template and post-event review.
+- AI Dev Days-owned event template and post-event review.
 
 ## Changed
 
 - Renamed the program and repository from OpenClaw Dev Days to AI Dev Days.
 - Reframed OpenClaw, Codex, and future technologies as tool-specific tracks.
+- Superseded the earlier framework-companion hierarchy; AI Dev Days now owns
+  its method, governance, and releases independently.
 - Renamed event folders to `event-specific/YYYY-MM-DD-<event-slug>/`.
 - Updated repository navigation, links, event metadata, embedded demo data,
   setup material, curriculum, contributor guidance, and generated PDFs.
@@ -61,7 +70,8 @@ Use [`MIGRATION.md`](../../MIGRATION.md) for the complete mapping.
 - The August 19, 2026 Houston Business Analysts packet does not yet include
   presentation slides.
 
-## Approval
+## Publication Record
 
-This document is release-candidate material. The official `v1.0.0` tag and
-GitHub release require the final audit and explicit founding steward approval.
+The founding steward approved publication on 2026-08-03. The official annotated
+`v1.0.0` tag and GitHub release are published only from the verified merged
+tree, with the exact release commit recorded in the GitHub release.

--- a/docs/research-and-education-method.md
+++ b/docs/research-and-education-method.md
@@ -1,9 +1,9 @@
 # AI Dev Days Research and Education Method
 
-**Status:** Version 1.0.0 release candidate  
-**Owner:** AI Dev Days founding steward or delegated program maintainer  
-**Prepared:** 2026-07-30  
-**Framework baseline:** [AI-Native Operating Framework 1.0.0](https://github.com/BradGroux/ai-native-operating-framework/releases/tag/v1.0.0)
+**Status:** Version 1.0.0<br>
+**Owner:** AI Dev Days founding steward or delegated program maintainer<br>
+**Prepared:** 2026-07-30<br>
+**Commons adoption:** [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0) at `27870fb1d57d951b9ef5a3a86f33ef068ee557da`
 
 ## Purpose
 
@@ -11,9 +11,7 @@ This method explains how AI Dev Days investigates a question, turns supported
 findings into education, uses that education with learners, and improves it
 from evidence.
 
-It adapts the framework's
-[standards maintenance method](https://github.com/BradGroux/ai-native-operating-framework/blob/v1.0.0/framework/standards-maintenance-method.md)
-to a research and education program:
+This is an AI Dev Days-owned, product-local method. Its maintenance sequence is:
 
 1. Understand
 2. Document
@@ -22,8 +20,11 @@ to a research and education program:
 5. Use
 6. Improve
 
-These are program-maintenance activities. They are not a mandatory lifecycle
-for every learner, event, business process, or research question.
+These are program-maintenance activities. They are not a Commons requirement
+or a mandatory lifecycle for every learner, event, business process, or
+research question. When a lesson selects another ecosystem product, a separate
+teaching guide may map this method to that product without transferring
+authority over AI Dev Days.
 
 ## Method at a Glance
 
@@ -60,7 +61,8 @@ for the consequence of the material.
 
 Prefer the source that owns the claim:
 
-- canonical framework documents for framework meaning;
+- the adopted Commons release for shared ecosystem principles and boundaries;
+- canonical framework documents when making claims about a named framework;
 - official product documentation and source code for tool behavior;
 - laws, regulations, standards, and government publications for public
   requirements;
@@ -215,7 +217,7 @@ record:
 
 - source facts;
 - analysis;
-- relevance to the framework and program;
+- relevance to Commons, any selected ecosystem product, and AI Dev Days;
 - what should and should not be reused;
 - remaining gaps; and
 - a recommendation or disposition.
@@ -271,7 +273,8 @@ usable, safe, and capable of producing its intended evidence.
 - confirm the facilitator can support mixed-skill participation;
 - inspect accessibility, readability, timing, and fallback material
   proportionately;
-- confirm tool-specific material does not redefine the framework; and
+- confirm tool-specific material does not redefine Commons, AI Dev Days, or a
+  selected ecosystem product; and
 - record unresolved limitations for the approver.
 
 ### Ready to Continue When
@@ -390,12 +393,13 @@ Consider:
 | Supersede | A newer or higher-authority record replaces the note | Old note remains historical and clearly marked |
 | Reject | Evidence, rights, relevance, or safety does not support reuse | No material change; reason remains visible |
 
-No research disposition changes the AI-Native Operating Framework. A proposed
-framework change must use the framework repository's contribution process.
+No research disposition changes Commons or another ecosystem product. A
+proposed change must use the repository and decision process of the product
+that owns the affected meaning.
 
-## Applying the Six Framework Concerns
+## Product-Local Completeness Lenses
 
-| Concern | Research and education question |
+| Lens | Research and education question |
 | --- | --- |
 | Intent | Why does this research or learning exist, for whom, and with what outcome? |
 | Responsibility | Who researches, teaches, participates, decides, reviews, and maintains? |
@@ -404,7 +408,8 @@ framework change must use the framework repository's contribution process.
 | Assurance | What checks, evidence, provenance, and review demonstrate a trustworthy result? |
 | Learning | How are outcomes, feedback, source changes, and lessons dispositioned and maintained? |
 
-The concerns are completeness lenses, not mandatory agenda phases.
+These are AI Dev Days completeness lenses, not Commons requirements or
+mandatory agenda phases.
 
 ## Program Measures
 
@@ -427,7 +432,7 @@ Do not invent metrics or turn anecdotal feedback into a rate.
 Stop research reuse, curriculum approval, event delivery, or release when:
 
 - material claims cannot be traced to an appropriate source;
-- the framework boundary is contradicted or unclear;
+- the Commons or selected-product boundary is contradicted or unclear;
 - source rights, consent, attribution, or publication safety is unresolved;
 - private, personal, confidential, or security-sensitive material may remain;
 - professional claims exceed available review;
@@ -441,7 +446,7 @@ Stop research reuse, curriculum approval, event delivery, or release when:
 - [AI Dev Days Charter](../CHARTER.md)
 - [Governance](../GOVERNANCE.md)
 - [Contribution SOP](../CONTRIBUTING.md)
-- [Framework alignment](ai-native-operating-framework-alignment.md)
+- [AI-Native Operating Framework teaching alignment](ai-native-operating-framework-alignment.md)
 - [AI Literacy Framework alignment](ai-literacy-framework-alignment.md)
 - [Research notes](../research/README.md)
 - [Event template](../event-specific/_template/README.md)

--- a/event-specific/2026-08-19-houston-business-analysts-codex/README.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/README.md
@@ -24,11 +24,12 @@ Business analysts already do much of the difficult work required to make AI usef
 
 Codex is the workbench for the session, but the durable method is the lesson. The method is to turn business knowledge into small, reviewable Markdown artifacts that people and agents can use together.
 
-## Operating foundation
+## Selected teaching alignment
 
-This event applies the
+This event explicitly selects the
 [AI-Native Operating Framework](../../docs/ai-native-operating-framework-alignment.md).
-The framework is canonical; this packet is an educational application.
+The framework is canonical for its own method; this packet and its learning
+design remain AI Dev Days-owned.
 
 - Intent: turn business-analysis practice into durable, reviewable AI context.
 - Responsibility: Brad owns the public packet and facilitation; attendees

--- a/event-specific/2026-08-19-houston-business-analysts-codex/facilitator-runbook.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/facilitator-runbook.md
@@ -7,8 +7,8 @@ Help business analysis practitioners see how their existing people, process, dat
 ## Before the room opens
 
 - review the
-  [AI-Native Operating Framework alignment](../../docs/ai-native-operating-framework-alignment.md)
-  and the event's operating-foundation mapping
+  [AI-Native Operating Framework teaching alignment](../../docs/ai-native-operating-framework-alignment.md)
+  and the event-specific mapping
 - confirm the final title and organizer inserts are in the deck once the slide
   phase is complete
 - confirm the projector, aspect ratio, display adapter, and power

--- a/event-specific/_template/README.md
+++ b/event-specific/_template/README.md
@@ -25,8 +25,8 @@ Also add the new event to [`../events.json`](../events.json) so the repo audit c
 - Post-event review owner: `<REVIEW_OWNER>`
 - Community/follow-up link: `<COMMUNITY_LINK>`
 
-Tool choices belong to the event's operating context. They do not change the
-AI-Native Operating Framework or define AI Dev Days as a whole.
+Tool and framework choices belong to the event's learning context. They do not
+change Commons, another ecosystem product, or AI Dev Days as a whole.
 
 ## Event files
 
@@ -41,7 +41,9 @@ AI-Native Operating Framework or define AI Dev Days as a whole.
 
 - [Root start page](../../START-HERE.md)
 - [Root facilitator runbook](../../RUNBOOK.md)
-- [AI-Native Operating Framework alignment](../../docs/ai-native-operating-framework-alignment.md)
+- [AI Dev Days Charter and Commons adoption](../../CHARTER.md)
+- [AI-Native Operating Framework teaching alignment](../../docs/ai-native-operating-framework-alignment.md),
+  when selected by the event
 - [Research and education method](../../docs/research-and-education-method.md)
 - [Research source note template](../../research/source-note-template.md)
 - [First success lab](../../labs/first-success.md)
@@ -50,7 +52,7 @@ AI-Native Operating Framework or define AI Dev Days as a whole.
 - [Publication safety](../../PUBLICATION-SAFETY.md)
 - [Event refresh checklist](../refresh-checklist.md)
 
-## Framework readiness
+## Event readiness
 
 Before approval, confirm the packet makes the following business meaning clear
 without forcing a particular document layout:

--- a/event-specific/refresh-checklist.md
+++ b/event-specific/refresh-checklist.md
@@ -12,15 +12,17 @@ Use this before publishing a new event packet or reusing an older one.
 - [ ] `README.md` and `START-HERE.md` point to the correct attendee path if the event should be visible from the repo root.
 - [ ] Past-event language is clearly historical, not written as if the event is still upcoming.
 
-## Framework Application
+## Program And Selected-Framework Application
 
 - [ ] The
-      [AI-Native Operating Framework alignment](../docs/ai-native-operating-framework-alignment.md)
+      [AI Dev Days Charter and Commons adoption](../CHARTER.md) was reviewed.
+- [ ] If the event selects the AI-Native Operating Framework, its
+      [teaching alignment](../docs/ai-native-operating-framework-alignment.md)
       was reviewed.
 - [ ] Intent, responsibility, work, control, assurance, and learning are clear
       in the packet without forcing a particular layout.
-- [ ] The tool track follows the event need and is not presented as a framework
-      requirement.
+- [ ] The tool track and any selected framework follow the event need and are
+      not presented as requirements for AI Dev Days as a whole.
 - [ ] Normal, meaningful exception, and credible failure/recovery scenarios
       were walked through.
 - [ ] Sources, decisions, current state, evidence, handoffs, and approved

--- a/research/README.md
+++ b/research/README.md
@@ -12,19 +12,21 @@ context.
 ## Authority
 
 Research notes are evidence and planning records. They are not attendee
-instructions, approved curriculum, program decisions, professional advice, or
-AI-Native Operating Framework requirements.
+instructions, approved curriculum, program decisions, professional advice,
+Commons principles, or requirements of another ecosystem product.
 
 Apply this order:
 
-1. The canonical
-   [AI-Native Operating Framework](https://github.com/BradGroux/ai-native-operating-framework)
-   governs framework meaning.
-2. [`CHARTER.md`](../CHARTER.md), accepted
+1. [`CHARTER.md`](../CHARTER.md), accepted
    [decisions](../decisions/README.md), and
    [`GOVERNANCE.md`](../GOVERNANCE.md) govern AI Dev Days.
-3. Approved curriculum, setup guides, and event packets govern current use.
-4. Research supplies bounded evidence and proposals.
+2. The adopted
+   [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+   governs shared ecosystem principles and boundaries.
+3. A selected framework's canonical repository governs representations of its
+   own meaning.
+4. Approved curriculum, setup guides, and event packets govern current use.
+5. Research supplies bounded evidence and proposals.
 
 When a note conflicts with a higher-authority or newer source, mark it
 superseded or record the conflict. Do not silently rewrite history.
@@ -38,7 +40,7 @@ records:
 - primary sources inspected and capture dates;
 - freshness and drift risk;
 - source facts separated from analysis;
-- relevance to the framework and AI Dev Days;
+- relevance to Commons, a named ecosystem product, or AI Dev Days;
 - what should and should not be reused;
 - rights, attribution, consent, and publication limits;
 - uncertainty, conflicts, remaining gaps, and required review; and
@@ -48,7 +50,8 @@ records:
 
 Prefer the source that owns the claim:
 
-- canonical framework documents for framework meaning;
+- the adopted Commons release for shared principles and boundaries;
+- canonical framework documents for claims about a named framework;
 - official documentation and source code for tools;
 - original laws, regulations, standards, government publications, or research;
 - accountable practitioner records for operating experience; and

--- a/research/digital-meld-operating-research.md
+++ b/research/digital-meld-operating-research.md
@@ -3,8 +3,8 @@
 - **Date:** 2026-07-30
 - **Researcher:** Prepared for Brad Groux with AI-assisted source comparison
   and drafting
-- **Status:** Accepted as evidence for the AI Dev Days version 1.0.0 release
-  candidate; not a framework decision
+- **Status:** Accepted as bounded evidence for AI Dev Days version 1.0.0;
+  relationship wording superseded by ADR-002; not a framework decision
 - **Public-safety status:** Public sources and public-safe synthesis
 
 ## Question
@@ -12,6 +12,11 @@
 Which durable lessons from Digital Meld's public operating research should
 inform AI Dev Days as a research and education companion to the AI-Native
 Operating Framework?
+
+This question records the relationship in effect when the research was
+prepared. [ADR-002](../decisions/0002-adopt-open-framework-commons-v1.0.0.md)
+supersedes the companion hierarchy while retaining the bounded source evidence
+for AI Dev Days' product-local method.
 
 ## Primary Sources Inspected
 

--- a/research/source-note-template.md
+++ b/research/source-note-template.md
@@ -50,10 +50,16 @@ interpretation. Link each material claim to the source that owns it.
 Explain patterns, conflicts, implications, and bounded inferences. Label
 inference and uncertainty.
 
+## Relevance to Commons or Another Ecosystem Product
+
+Explain which shared Commons boundary or named product concern is relevant.
+Research does not amend Commons or another ecosystem product.
+
 ## Relevance to the AI-Native Operating Framework
 
-Explain which canonical framework concerns or methods are relevant. Research
-does not amend the framework.
+When the research concerns this framework, explain which canonical concern or
+method is relevant. Otherwise mark this section not applicable. Research does
+not amend the framework.
 
 ## Relevance to AI Dev Days
 


### PR DESCRIPTION
## Summary

Adopt Open Framework Commons v1.0.0 as AI Dev Days' shared philosophical foundation while preserving AI Dev Days as an independent learning community and event repository.

Contribution class: material program decision and release documentation.

Closes #104. Records the decision in ADR-002 and supersedes ADR-001's earlier framework-companion hierarchy.

## Commons Release Pin

- Repository: https://github.com/BradGroux/open-framework-commons
- Tag: `v1.0.0`
- Release commit: `27870fb1d57d951b9ef5a3a86f33ef068ee557da`
- Verification: the annotated tag was confirmed to peel exactly to that commit.

## Alignment Disposition

- **Adopted:** all Commons v1.0.0 shared principles and boundaries by reference.
- **Product-local:** AI Dev Days' purpose, audience, research and education method, curriculum, event operations, community practices, examples, publication safety, contribution flow, governance, roadmap, and releases.
- **Corrected:** the prior description of AI Dev Days as a companion governed by the AI-Native Operating Framework. That framework remains optional teaching material and canonical only for its own meaning.
- **Deferred:** Commons-driven software, schemas, runtimes, conformance systems, shared data, CI, validators, and repository structure. Commons v1.0.0 does not require them.
- **Deviations:** none from Commons v1.0.0.

## Foundations

No new foundational policy document was added. The existing charter, governance, Code of Conduct, security policy, and MIT license each retain a distinct AI Dev Days reader job.

ADR-002 is new because current governance requires a decision record for a material ecosystem-product relationship change. The charter was reduced to product-local commitments so Commons principles are not duplicated.

## Files Changed

- Updated public navigation, charter, context, governance, contribution guidance, changelog, citation metadata, migration guidance, and v1.0.0 release notes.
- Reframed the AI-Native Operating Framework document as an optional teaching alignment.
- Preserved the AI Dev Days-owned research method, curriculum, reusable event template, and current Houston event operations while correcting authority wording.
- Updated contributor issue and pull request templates to enforce Commons and product-independence boundaries.
- Added ADR-002 and marked ADR-001 superseded without rewriting the historical record.

No software, schema, CI, validator, generated asset, or unrelated event content changed.

## Independence Boundary

AI Dev Days independently owns its curriculum, events, community practices, examples, research, governance, roadmap, and releases. Commons is not a parent product or operating method. Teaching another ecosystem product does not make AI Dev Days its module or inherit that product's method.

## Verification

- `./scripts/validate-release.sh` passed after every review finding was resolved.
- `node scripts/audit-repo.mjs` passed.
- `bash scripts/publication-scan.sh` passed.
- `node scripts/check-external-links.mjs` passed: 109 URLs checked, 12 volatile or same-repository URLs skipped, and two non-blocking host warnings returned HTTP 400/403.
- Fictional Houston demo verification passed.
- YAML parsing passed, including the changed issue templates and `CITATION.cff`.
- Dependency audit found 0 vulnerabilities.
- Beaver Badges typecheck, production build, and Playwright visual smoke passed.
- Independent standards and specification reviews reported no findings after fixes.

## Publication Safety

- [x] No secrets, credentials, private data, customer records, internal screenshots, local paths, or sensitive operational details were added.
- [x] Event-specific assumptions remain under `event-specific/`.
- [x] The changelog now records the dated 1.0.0 release.
- [x] Commons prose is referenced, not copied into a second canonical list.

## Unresolved Decisions And Limitations

No owner decision remains unresolved. The founding steward authorized v1.0.0 publication on 2026-08-03 after this PR is merged and the merged tree is verified.

The release still records these limitations: the full research-to-education method has not yet been measured through a complete new-event lifecycle; historical event review depth varies; OpenClaw remains the most developed tool track; and the August 19 Houston packet does not yet include slides.

## Release Decision

Merge after repository checks and required reviews pass. Then compare the merged tree with reviewed commit `d60c88c`; rerun affected validation if content differs. Publish a new immutable annotated `v1.0.0` tag and GitHub release from the verified merged commit. Do not move an existing tag.
