### PR TITLE
Refresh v1 dependencies and add program map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,17 @@
   metadata for the version 1.0.0 baseline.
 - Added a canonical research and education method that carries source-grounded
   findings through Understand, Document, Validate, Approve, Use, and Improve.
+- Added a visual program map for the research-to-learning loop and the boundary
+  between Commons, AI Dev Days-owned work, and selected teaching contexts.
 - Added a public-source Digital Meld operating-research synthesis with explicit
   reuse boundaries and program implications.
 - Added an explicit release process and prepared version 1.0.0 release notes
   with an owner approval gate.
 - Updated the Beaver Badges PostCSS development dependency to a patched release
   and added a high-severity dependency audit to the release validation gate.
+- Refreshed the Beaver Badges React, React DOM, React types, Tailwind CSS,
+  TypeScript, and Vite dependencies and moved the quality workflow to
+  `actions/setup-node@v7`.
 - Renamed all dated event folders to the `YYYY-MM-DD-<event-slug>` convention
   and updated repository navigation, metadata, embedded seed data, and links.
 - Added repository and event-path migration guidance.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ has no authority on its own, event experience does not become reusable
 curriculum automatically, and every material lesson receives an accountable
 disposition.
 
+For a visual orientation to that learning loop and the Commons ownership
+boundary, use the [`AI Dev Days Program Map`](docs/program-map.md).
+
 ## Choose your path
 
 Start with [`START-HERE.md`](START-HERE.md) if you are not sure which file you need.
@@ -47,6 +50,8 @@ Start with [`START-HERE.md`](START-HERE.md) if you are not sure which file you n
 - Curriculum: use [`curriculum/README.md`](curriculum/README.md) and [`curriculum/course-map.md`](curriculum/course-map.md).
 - Shared foundation and independence: use [`CHARTER.md`](CHARTER.md) and the
   adopted [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0).
+- Visual program orientation: use
+  [`docs/program-map.md`](docs/program-map.md).
 - AI-Native Operating Framework teaching guide: use
   [`docs/ai-native-operating-framework-alignment.md`](docs/ai-native-operating-framework-alignment.md)
   when an event or lesson selects that framework.

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -6,13 +6,14 @@ Use this page to choose the shortest useful path through the repo.
 
 Start with:
 
-1. [AI Dev Days Charter](CHARTER.md)
-2. [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
-3. [Governance](GOVERNANCE.md)
-4. [Research and education method](docs/research-and-education-method.md)
-5. [Curriculum overview](curriculum/README.md)
-6. [Facilitator runbook](RUNBOOK.md)
-7. [Event template](event-specific/_template/README.md)
+1. [Visual program map](docs/program-map.md)
+2. [AI Dev Days Charter](CHARTER.md)
+3. [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+4. [Governance](GOVERNANCE.md)
+5. [Research and education method](docs/research-and-education-method.md)
+6. [Curriculum overview](curriculum/README.md)
+7. [Facilitator runbook](RUNBOOK.md)
+8. [Event template](event-specific/_template/README.md)
 
 For an event or lesson that selects the AI-Native Operating Framework, use the
 [product-local teaching guide](docs/ai-native-operating-framework-alignment.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ visual reference material for AI Dev Days.
 
 ## Shared foundation
 
+- [Visual program map](program-map.md)
 - [AI Dev Days Charter](../CHARTER.md)
 - [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
 

--- a/docs/program-map.md
+++ b/docs/program-map.md
@@ -1,0 +1,83 @@
+# AI Dev Days Program Map
+
+These diagrams are orientation aids for readers. The linked charter,
+governance, methods, and decisions remain authoritative.
+
+## From Research to Reusable Learning
+
+```mermaid
+flowchart LR
+    S["Public sources and practitioner questions"]
+    R["Source-grounded research"]
+    D{"Accountable disposition"}
+    C["Reusable curriculum and labs"]
+    E["Event-specific packet"]
+    W["Reviewable learner work"]
+    P["Post-event review"]
+    K["Recorded deferment, rejection, or open question"]
+    T["Selected tools or ecosystem products"]
+
+    S --> R --> D
+    D -- "Accept" --> C --> E --> W --> P
+    D -- "Revise" --> R
+    D -- "Defer or reject" --> K
+    T -- "Teaching context only" --> E
+    P -. "New evidence" .-> R
+```
+
+Read the flow from left to right:
+
+1. Public sources and practitioner questions become bounded research, not
+   instructions by default.
+2. An accountable AI Dev Days decision accepts, revises, defers, or rejects a
+   proposed lesson.
+3. Approved learning becomes reusable curriculum before an organizer adapts it
+   into an event-specific packet.
+4. Selected tools or ecosystem products provide teaching context only.
+5. Reviewable learner work and post-event observations return as new evidence;
+   they do not become standards automatically.
+
+The canonical process is the
+[research and education method](research-and-education-method.md). Event
+delivery uses the [facilitator runbook](../RUNBOOK.md) and
+[event template](../event-specific/_template/README.md).
+
+## Shared Foundation and Local Ownership
+
+```mermaid
+flowchart TB
+    subgraph Shared["Open Framework Commons"]
+        C["Shared principles and boundaries"]
+    end
+
+    subgraph Local["AI Dev Days owns"]
+        G["Charter, governance, and releases"]
+        M["Research and education method"]
+        L["Curriculum, labs, and examples"]
+        E["Events and community practices"]
+        R["Evidence and local decisions"]
+
+        G --> M --> L --> E --> R
+        R -. "Approved improvement" .-> M
+    end
+
+    subgraph Context["Selected teaching context"]
+        F["Ecosystem frameworks"]
+        T["OpenClaw, Codex, and other tools"]
+    end
+
+    C -. "Adopted by reference" .-> G
+    F -- "Only when selected" --> L
+    T -- "Only when selected" --> E
+```
+
+The boundary is deliberate:
+
+- [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+  is authoritative for the shared principles and boundaries AI Dev Days adopts
+  by reference.
+- [AI Dev Days](../CHARTER.md) is authoritative for its purpose, method,
+  curriculum, events, community practices, governance, roadmap, and releases.
+- A selected framework remains authoritative for its own meaning, and a
+  selected tool remains implementation context. Neither gains authority over
+  the AI Dev Days program.

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -32,6 +32,8 @@ date-first convention.
   alignment.
 - Open Framework Commons v1.0.0 adoption with an explicit product-independence
   boundary.
+- A visual program map for the research-to-learning loop and the boundary among
+  Commons, AI Dev Days-owned work, and selected teaching contexts.
 - Release process with an explicit owner approval gate.
 - Date-first event-folder validation and migration guidance.
 - AI Dev Days-owned event template and post-event review.
@@ -47,6 +49,9 @@ date-first convention.
   setup material, curriculum, contributor guidance, and generated PDFs.
 - Regenerated three source-backed slide PDFs at 1920 by 1080 rendering quality
   with current repository links and clickable annotations.
+- Refreshed the Beaver Badges React, React DOM, React types, Tailwind CSS,
+  TypeScript, and Vite dependencies and moved the quality workflow to
+  `actions/setup-node@v7`.
 
 ## Migration
 

--- a/projects/beaver-badges/app/package-lock.json
+++ b/projects/beaver-badges/app/package-lock.json
@@ -8,18 +8,18 @@
       "name": "beaver-badges",
       "version": "0.0.1",
       "dependencies": {
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
-        "@types/react": "^19.2.2",
+        "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.2",
         "@vitejs/plugin-react": "^6.0.3",
         "autoprefixer": "^10.5.2",
         "postcss": "^8.5.25",
-        "tailwindcss": "^4.3.0",
-        "typescript": "^6.0.3",
+        "tailwindcss": "^4.3.3",
+        "typescript": "^7.0.2",
         "vite": "^8.1.5"
       }
     },
@@ -399,9 +399,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -416,6 +416,346 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1024,24 +1364,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/rolldown": {
@@ -1095,9 +1435,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1127,17 +1467,38 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/projects/beaver-badges/app/package.json
+++ b/projects/beaver-badges/app/package.json
@@ -12,18 +12,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
-    "@types/react": "^19.2.2",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.5.2",
     "postcss": "^8.5.25",
-    "tailwindcss": "^4.3.0",
-    "typescript": "^6.0.3",
+    "tailwindcss": "^4.3.3",
+    "typescript": "^7.0.2",
     "vite": "^8.1.5"
   }
 }

--- a/scripts/audit-repo.mjs
+++ b/scripts/audit-repo.mjs
@@ -23,6 +23,7 @@ const requiredFiles = [
   'decisions/TEMPLATE.md',
   'decisions/0001-framework-companion-for-research-and-education.md',
   'docs/ai-native-operating-framework-alignment.md',
+  'docs/program-map.md',
   'docs/research-and-education-method.md',
   'docs/release-process.md',
   'docs/releases/v1.0.0.md',


### PR DESCRIPTION
## Summary

- consolidates the remaining Beaver Badges updates from Dependabot PRs #78, #79, #80, and #81 on current `master`
- updates React, React DOM, React types, Tailwind CSS, and TypeScript while preserving the Vite update merged in #82
- adds a GitHub-native visual program map for the research-to-learning loop and the Open Framework Commons ownership boundary
- makes the new program map part of the repository audit and updates v1.0.0 navigation, changelog, and release notes

## Root cause

The remaining Dependabot branches changed the same package lockfile and could not all be refreshed after #82 merged. PR #78 also had a stale visual-smoke timeout even though its audit, typecheck, and build passed. Updating the related React packages together from current `master` resolves the lockfile conflict and the smoke failure.

## Dependency updates

- `react`: 19.2.6 to 19.2.8
- `react-dom`: 19.2.6 to 19.2.8
- `@types/react`: declared 19.2.2 to 19.2.17
- `tailwindcss`: 4.3.0 to 4.3.3
- `typescript`: 6.0.3 to 7.0.2
- `vite`: 8.1.0 to 8.1.5 through merged PR #82
- `actions/setup-node`: 6 to 7 through merged PR #95

## Visual documentation

`docs/program-map.md` contains two Mermaid diagrams with adjacent text alternatives:

1. research, accountable disposition, curriculum, event use, learner evidence, and post-event feedback
2. the boundary among Commons-owned principles, AI Dev Days-owned program work, and selected teaching contexts

The diagrams adopt Commons by reference and preserve AI Dev Days as an independent learning community and event repository.

## Validation

- `npm ci`
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm run check`: TypeScript 7 typecheck and Vite 8.1.5 production build passed
- `npm run smoke:visual`: passed with React and React DOM 19.2.8
- `./scripts/validate-release.sh`: passed
- Mermaid CLI render check for both diagrams: passed and visually inspected
- independent standards review: one routing issue found, fixed, and re-reviewed with no remaining findings
- independent specification review: no findings

The external-link gate checked 109 URLs and retained the existing two non-blocking blocked-host warnings.

## Release decision

After merge and a passing default-branch quality run, republish the existing `v1.0.0` release from the final verified `master` commit as explicitly requested by the release owner.

Closes #106

Supersedes #78, #79, #80, and #81.
