### PR TITLE
Publish Commons pin refresh review and exact historical links

### DIFF
--- a/decisions/0002-adopt-open-framework-commons-v1.0.0.md
+++ b/decisions/0002-adopt-open-framework-commons-v1.0.0.md
@@ -101,5 +101,5 @@ refreshed.
 
 - [Open Framework Commons repository](https://github.com/BradGroux/open-framework-commons)
 - [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
-- [Open Framework Commons v1.0.0 boundaries](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/BOUNDARIES.md)
-- [Open Framework Commons v1.0.0 governance](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/GOVERNANCE.md)
+- [Original Open Framework Commons boundaries](https://github.com/BradGroux/open-framework-commons/blob/27870fb1d57d951b9ef5a3a86f33ef068ee557da/BOUNDARIES.md)
+- [Original Open Framework Commons governance](https://github.com/BradGroux/open-framework-commons/blob/27870fb1d57d951b9ef5a3a86f33ef068ee557da/GOVERNANCE.md)

--- a/decisions/0003-refresh-open-framework-commons-v1.0.0-pin.md
+++ b/decisions/0003-refresh-open-framework-commons-v1.0.0-pin.md
@@ -116,5 +116,5 @@ boundaries is recorded.
 - [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
 - [Replacement Commons commit](https://github.com/BradGroux/open-framework-commons/commit/a0f0d384e9010a65d1a21a324b4c912433d5e031)
 - [Original Commons commit](https://github.com/BradGroux/open-framework-commons/commit/27870fb1d57d951b9ef5a3a86f33ef068ee557da)
-- [Commons shared boundaries](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/BOUNDARIES.md)
-- [Commons governance](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/GOVERNANCE.md)
+- [Replacement Commons shared boundaries](https://github.com/BradGroux/open-framework-commons/blob/a0f0d384e9010a65d1a21a324b4c912433d5e031/BOUNDARIES.md)
+- [Replacement Commons governance](https://github.com/BradGroux/open-framework-commons/blob/a0f0d384e9010a65d1a21a324b4c912433d5e031/GOVERNANCE.md)

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -89,4 +89,6 @@ Use [`MIGRATION.md`](../../MIGRATION.md) for the complete mapping.
 
 The founding steward approved publication on 2026-08-03. The official annotated
 `v1.0.0` tag and GitHub release are published only from the verified merged
-tree, with the exact release commit recorded in the GitHub release.
+tree, with the exact release commit recorded in the GitHub release. The
+[coordinated Commons refresh review](../reviews/open-framework-commons-v1.0.0-coordinated-refresh-review-2026-08-03.md)
+records the sanitized candidate findings and validation limits.

--- a/docs/reviews/open-framework-commons-v1.0.0-coordinated-refresh-review-2026-08-03.md
+++ b/docs/reviews/open-framework-commons-v1.0.0-coordinated-refresh-review-2026-08-03.md
@@ -1,0 +1,60 @@
+# Open Framework Commons v1.0.0 Coordinated Refresh Review
+
+- **Status:** PASS
+- **Date:** 2026-08-03
+- **Review roles:** independent standards review; independent specification review
+- **Accountable owner:** Brad Groux
+- **Issue:** [#108](https://github.com/BradGroux/ai-dev-days/issues/108)
+- **Fixed point:** `70999e048685d0103e1ed3e7af41dffb390bfac9`
+- **Reviewed candidate:** `35e69b678c22bb8f6610fe9458aad89cccc8eb23`
+
+## Scope
+
+The review checked the documentation-only change that refreshes AI Dev Days'
+exact Open Framework Commons `v1.0.0` pin from
+`27870fb1d57d951b9ef5a3a86f33ef068ee557da` to
+`a0f0d384e9010a65d1a21a324b4c912433d5e031`.
+
+The review also checked that the Commons visual guides and active-product
+status do not alter AI Dev Days' curriculum, events, research and education
+method, governance, or independent release authority.
+
+## Findings
+
+| Review | Result | Open findings |
+| --- | --- | --- |
+| Standards and publication integrity | PASS | None after one Minor historical-link correction |
+| Issue requirements and scope | PASS | None |
+
+The prior Commons commit remains only in explicit old-to-new release history.
+The owner-authorized replacement of the product `v1.0.0` tag is documented
+together with the immutable-tag risk and both Commons states. No historical
+review or unrelated event, curriculum, research, or tool-track content changed.
+
+The first standards pass found one Minor issue: the original ADR used
+tag-relative deep links for its historical Commons sources, and the replacement
+ADR repeated those moving links. The follow-up pins ADR-002's boundaries and
+governance sources to the original Commons commit and ADR-003's corresponding
+sources to the replacement commit. The recheck found no open issue.
+
+## Verification
+
+- `git diff --check`
+- `./scripts/validate-release.sh`
+- repository audit and publication-safety scan
+- internal and external link checks
+- original and replacement ADR source links pinned to their exact Commons commits
+- fictional demo verification
+- YAML and citation metadata parsing
+- dependency audit, typecheck, production build, and visual smoke test
+
+The complete release validation gate passed. Two external hosts returned
+non-blocking 400/403 warnings already handled by the repository checker; 12
+volatile or same-repository URLs were intentionally skipped.
+
+## Limitations
+
+This is documentation and release-integrity evidence, not learner-outcome,
+accessibility, domain, organizational, professional, or real-world validation.
+Merge identity, hosted checks, tag replacement, and GitHub release publication
+remain separate delivery steps.


### PR DESCRIPTION
## Summary

PR #111 already merged the coordinated Commons v1.0.0 pin refresh. This follow-up completes issue #108 by:

- publishing the sanitized standards/specification review for exact merged candidate `35e69b678c22bb8f6610fe9458aad89cccc8eb23`
- linking the v1.0.0 release record to that review
- pinning ADR-002 historical source links to original Commons commit `27870fb1d57d951b9ef5a3a86f33ef068ee557da`
- pinning ADR-003 replacement source links to current Commons commit `a0f0d384e9010a65d1a21a324b4c912433d5e031`

## Verification

- `./scripts/validate-release.sh`
- Standards recheck: GO, no findings after one Minor historical-link correction
- Specification recheck: PASS, no findings

Closes #108