### PR TITLE
Refresh the Open Framework Commons v1.0.0 commit pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ## 1.0.0 - 2026-08-03
 
-- Adopted Open Framework Commons v1.0.0 at release commit
-  `27870fb1d57d951b9ef5a3a86f33ef068ee557da` while preserving AI Dev Days as
-  an independent learning community that owns its curriculum, events,
-  community practices, examples, research, governance, roadmap, and releases.
+- Adopted Open Framework Commons v1.0.0, initially at
+  `27870fb1d57d951b9ef5a3a86f33ef068ee557da`, and refreshed the exact pin to
+  `a0f0d384e9010a65d1a21a324b4c912433d5e031` after Commons republished the
+  tag. AI Dev Days remains an independent learning community that owns its
+  curriculum, events, community practices, examples, research, governance,
+  roadmap, and releases.
 - Renamed the repository and program from OpenClaw Dev Days to AI Dev Days
   while preserving OpenClaw as a tool-specific track.
 - Added an AI-Native Operating Framework teaching guide for events or lessons

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -84,7 +84,7 @@ foundation:
 
 - **Repository:** [BradGroux/open-framework-commons](https://github.com/BradGroux/open-framework-commons)
 - **Adopted tag:** [`v1.0.0`](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
-- **Release commit:** [`27870fb1d57d951b9ef5a3a86f33ef068ee557da`](https://github.com/BradGroux/open-framework-commons/commit/27870fb1d57d951b9ef5a3a86f33ef068ee557da)
+- **Release commit:** [`a0f0d384e9010a65d1a21a324b4c912433d5e031`](https://github.com/BradGroux/open-framework-commons/commit/a0f0d384e9010a65d1a21a324b4c912433d5e031)
 
 Commons owns shared principles and boundaries only. AI Dev Days independently
 owns its curriculum, events, community practices, examples, research,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -240,14 +240,18 @@ Before release:
 
 - **Version:** 1.0.0
 - **Commons adoption:** Open Framework Commons v1.0.0 at
-  `27870fb1d57d951b9ef5a3a86f33ef068ee557da`
+  `a0f0d384e9010a65d1a21a324b4c912433d5e031`
+- **Commons pin history:** initially
+  `27870fb1d57d951b9ef5a3a86f33ef068ee557da`; refreshed on 2026-08-03 after
+  the Commons `v1.0.0` tag was republished
 - **Product-specific teaching baseline:** AI-Native Operating Framework 1.0.0
   where a lesson or event selects it
 - **Prepared date:** 2026-07-30
 - **Repository tag:** `v1.0.0`
-- **Release authorization:** approved by the founding steward on 2026-08-03,
-  conditional on the reviewed migration being merged and the merged tree being
-  verified
+- **Release authorization:** approved by the founding steward on 2026-08-03;
+  the same authority later approved retaining version 1.0.0 and refreshing its
+  Commons pin, conditional on the current reviewed update being merged and the
+  merged tree being verified
 - **Superseded public version:** none
 - **Responsible steward:** Brad Groux
 - **Known limitations:** event outcomes have not yet been measured under the

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ as its shared philosophical foundation. The adopted release is pinned to:
 
 - repository: [BradGroux/open-framework-commons](https://github.com/BradGroux/open-framework-commons)
 - tag: [`v1.0.0`](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
-- release commit: [`27870fb1d57d951b9ef5a3a86f33ef068ee557da`](https://github.com/BradGroux/open-framework-commons/commit/27870fb1d57d951b9ef5a3a86f33ef068ee557da)
+- release commit: [`a0f0d384e9010a65d1a21a324b4c912433d5e031`](https://github.com/BradGroux/open-framework-commons/commit/a0f0d384e9010a65d1a21a324b4c912433d5e031)
 
 Commons supplies shared principles and boundaries; it is not a parent product
 or operating method. AI Dev Days independently owns its curriculum, events,

--- a/decisions/0002-adopt-open-framework-commons-v1.0.0.md
+++ b/decisions/0002-adopt-open-framework-commons-v1.0.0.md
@@ -1,8 +1,13 @@
 # ADR-002: Adopt Open Framework Commons v1.0.0 and Preserve Product Independence
 
-- **Status:** accepted
+- **Status:** accepted; exact commit pin refreshed by ADR-003
 - **Date:** 2026-08-03
 - **Owner:** Brad Groux
+
+> This record preserves the original adoption decision at
+> `27870fb1d57d951b9ef5a3a86f33ef068ee557da`. The current Commons v1.0.0 pin
+> is `a0f0d384e9010a65d1a21a324b4c912433d5e031`; see
+> [ADR-003](0003-refresh-open-framework-commons-v1.0.0-pin.md).
 
 ## Question
 
@@ -76,6 +81,10 @@ No deviation from the Commons v1.0.0 shared principles is recorded.
 The founding steward authorized publishing AI Dev Days `v1.0.0` on 2026-08-03
 after the migration is merged and the merged tree is verified. The tag must be
 new and immutable; no published tag may be moved.
+
+ADR-003 records the later owner-approved exception that retained version 1.0.0
+after Commons republished its own tag and required the exact adoption pin to be
+refreshed.
 
 ## Affected Artifacts
 

--- a/decisions/0003-refresh-open-framework-commons-v1.0.0-pin.md
+++ b/decisions/0003-refresh-open-framework-commons-v1.0.0-pin.md
@@ -1,0 +1,120 @@
+# ADR-003: Refresh the Open Framework Commons v1.0.0 Commit Pin
+
+- **Status:** accepted
+- **Date:** 2026-08-03
+- **Owner:** Brad Groux
+
+## Question
+
+Which exact Open Framework Commons commit should AI Dev Days adopt after the
+Commons owner republished the existing `v1.0.0` tag while retaining that
+version number?
+
+## Context and Evidence
+
+ADR-002 originally adopted Commons v1.0.0 at
+`27870fb1d57d951b9ef5a3a86f33ef068ee557da`.
+
+On 2026-08-03, the live Commons `v1.0.0` tag was verified as an annotated tag
+that peels to `a0f0d384e9010a65d1a21a324b4c912433d5e031`. Commons `main` resolved to
+the same commit.
+
+The change from the original commit updates Commons documentation only. It:
+
+- strengthens the shared-versus-product-local boundary and adoption flow;
+- records Relationship Operating Framework as active;
+- adds three visual guides and their review record; and
+- links the four products' separate adoption records.
+
+No Commons shared principle was removed, and the revised boundary continues to
+state that AI Dev Days is an independent learning community that owns its own
+charter, program, and decisions. AI Dev Days' existing program map and local
+ownership statements remain consistent with that guidance.
+
+The Commons visualization review still names the original commit because it
+records the state reviewed before the later release decision. It is historical
+review evidence, not the current tag target.
+
+## Alternatives Considered
+
+### Keep the original commit pin
+
+This would preserve the original immutable reference, but AI Dev Days would no
+longer identify the commit currently published as Commons v1.0.0. That would be
+an explicit local deviation from the release named in public navigation.
+
+### Wait for a new Commons version
+
+No new Commons version was published. The Commons owner explicitly designated
+the replacement commit as v1.0.0 and directed AI Dev Days to keep version
+1.0.0.
+
+### Refresh the exact pin and preserve the transition record
+
+This keeps the named Commons release and exact commit aligned while retaining
+the original commit in the decision and release history.
+
+## Recommendation
+
+Refresh the exact Commons v1.0.0 commit pin, preserve the original commit as
+explicit history, retain AI Dev Days version 1.0.0, and refresh the existing AI
+Dev Days release only after the reviewed documentation update is merged and the
+merged tree is verified.
+
+## Decision
+
+AI Dev Days retains version 1.0.0 and adopts Open Framework Commons v1.0.0 at
+[`a0f0d384e9010a65d1a21a324b4c912433d5e031`](https://github.com/BradGroux/open-framework-commons/commit/a0f0d384e9010a65d1a21a324b4c912433d5e031).
+
+Current charter, governance, method, navigation, and release records must use
+the replacement commit. Historical records may retain
+`27870fb1d57d951b9ef5a3a86f33ef068ee557da` when they identify it explicitly as
+the original pin.
+
+The Commons documentation changes do not alter AI Dev Days' independent
+purpose, authority, research and education method, curriculum, events,
+community practices, examples, roadmap, or releases.
+
+Because the corrected pin changes the version 1.0.0 documentation tree, the AI
+Dev Days `v1.0.0` tag and GitHub release are refreshed after the reviewed merge
+instead of creating a new version.
+
+## Consequences
+
+- Public entry points resolve the Commons version and commit consistently.
+- The original and replacement Commons commits remain visible in public
+  history.
+- No Commons prose, software, schema, runtime, conformance mechanism, or
+  repository structure is copied into AI Dev Days.
+- No curriculum, event, community, or tool-track material changes.
+
+## Dissent and Uncertainty
+
+Republishing a tag weakens immutable-reference expectations for anyone who
+already fetched it. Consumers with the original tag may need to force-refresh
+their tag reference. Exact commit pins and this transition record preserve the
+two states, but AI Dev Days cannot repair upstream tag history.
+
+No substantive deviation from the replacement Commons v1.0.0 principles or
+boundaries is recorded.
+
+## Affected Artifacts
+
+- `README.md`
+- `CHARTER.md`
+- `GOVERNANCE.md`
+- `CHANGELOG.md`
+- `docs/releases/v1.0.0.md`
+- `docs/research-and-education-method.md`
+- `decisions/README.md`
+- `decisions/0002-adopt-open-framework-commons-v1.0.0.md`
+- `scripts/audit-repo.mjs`
+
+## Sources
+
+- [Open Framework Commons repository](https://github.com/BradGroux/open-framework-commons)
+- [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0)
+- [Replacement Commons commit](https://github.com/BradGroux/open-framework-commons/commit/a0f0d384e9010a65d1a21a324b4c912433d5e031)
+- [Original Commons commit](https://github.com/BradGroux/open-framework-commons/commit/27870fb1d57d951b9ef5a3a86f33ef068ee557da)
+- [Commons shared boundaries](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/BOUNDARIES.md)
+- [Commons governance](https://github.com/BradGroux/open-framework-commons/blob/v1.0.0/GOVERNANCE.md)

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -9,6 +9,8 @@ practice.
 1. [ADR-001: Framework companion for research and education](0001-framework-companion-for-research-and-education.md)
    — superseded by ADR-002
 2. [ADR-002: Adopt Open Framework Commons v1.0.0 and preserve product independence](0002-adopt-open-framework-commons-v1.0.0.md)
+   — accepted; exact commit pin refreshed by ADR-003
+3. [ADR-003: Refresh the Open Framework Commons v1.0.0 commit pin](0003-refresh-open-framework-commons-v1.0.0-pin.md)
    — accepted
 
 Program decisions take effect independently of whether an AI Dev Days release

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,7 +1,7 @@
 # AI Dev Days 1.0.0
 
 **Status:** Approved initial release<br>
-**Commons adoption:** Open Framework Commons v1.0.0 at `27870fb1d57d951b9ef5a3a86f33ef068ee557da`<br>
+**Commons adoption:** Open Framework Commons v1.0.0 at `a0f0d384e9010a65d1a21a324b4c912433d5e031`<br>
 **Teaching compatibility:** AI-Native Operating Framework 1.0.0 when selected<br>
 **Prepared:** 2026-07-30<br>
 **Approved:** 2026-08-03<br>
@@ -18,6 +18,16 @@ AI-Native Operating Framework available as optional teaching material, and
 keeps the program vendor-neutral. It also changes the repository name from
 `openclaw-dev-days` to `ai-dev-days` and moves dated event folders to a
 date-first convention.
+
+## Commons Republication
+
+Open Framework Commons later republished its `v1.0.0` tag from
+`27870fb1d57d951b9ef5a3a86f33ef068ee557da` to
+`a0f0d384e9010a65d1a21a324b4c912433d5e031`. AI Dev Days retains version
+1.0.0 and now pins that replacement commit. The revised Commons documentation
+strengthens product independence, adoption governance, and visual orientation;
+it does not transfer ownership of AI Dev Days' method, curriculum, events,
+community practices, governance, or releases.
 
 ## Added
 

--- a/docs/research-and-education-method.md
+++ b/docs/research-and-education-method.md
@@ -3,7 +3,7 @@
 **Status:** Version 1.0.0<br>
 **Owner:** AI Dev Days founding steward or delegated program maintainer<br>
 **Prepared:** 2026-07-30<br>
-**Commons adoption:** [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0) at `27870fb1d57d951b9ef5a3a86f33ef068ee557da`
+**Commons adoption:** [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0) at `a0f0d384e9010a65d1a21a324b4c912433d5e031`
 
 ## Purpose
 

--- a/scripts/audit-repo.mjs
+++ b/scripts/audit-repo.mjs
@@ -22,6 +22,8 @@ const requiredFiles = [
   'decisions/README.md',
   'decisions/TEMPLATE.md',
   'decisions/0001-framework-companion-for-research-and-education.md',
+  'decisions/0002-adopt-open-framework-commons-v1.0.0.md',
+  'decisions/0003-refresh-open-framework-commons-v1.0.0-pin.md',
   'docs/ai-native-operating-framework-alignment.md',
   'docs/program-map.md',
   'docs/research-and-education-method.md',


### PR DESCRIPTION
## Summary

- updates the current Open Framework Commons v1.0.0 pin from `27870fb1d57d951b9ef5a3a86f33ef068ee557da` to `a0f0d384e9010a65d1a21a324b4c912433d5e031`
- keeps AI Dev Days at version 1.0.0 and preserves its independent learning-community authority
- adds ADR-003 to record the original pin, replacement pin, alternatives, release decision, and immutable-tag risk
- preserves ADR-002 as the original adoption record while pointing readers to the current decision
- makes both Commons adoption decisions required repository-audit artifacts

## Upstream verification

- Commons `v1.0.0` is an annotated tag with object `d1303411ea67768ee2fee5dfb21e82c2e8599a3a`
- the tag peels to `a0f0d384e9010a65d1a21a324b4c912433d5e031`
- Commons `main` resolves to the same commit
- the change from the original Commons pin is documentation-only and strengthens product boundaries, adoption governance, active-product references, and visual guidance
- no Commons shared principle was removed

## Release decision

No new AI Dev Days version is needed. Because the exact Commons pin changes the version 1.0.0 documentation tree and source archives, the existing AI Dev Days `v1.0.0` tag and GitHub release should be refreshed only after this PR is merged and the exact merged tree is verified.

## Validation

- `npm ci`
- `./scripts/validate-release.sh`
- publication safety scan passed
- repository audit passed: 352 files scanned and 33 required files checked
- external link check passed: 110 URLs checked; existing blocked-host warnings remained non-blocking
- dependency audit found 0 vulnerabilities
- TypeScript typecheck, Vite production build, and Playwright visual smoke passed
- independent specification review: no findings
- independent standards review: three findings fixed and re-reviewed with no remaining findings

Closes #109
