### PR TITLE
Add Mermaid diagrams to HOUBAs event materials

### DIFF
--- a/event-specific/2026-08-19-houston-business-analysts-codex/README.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/README.md
@@ -42,6 +42,21 @@ demo; fictional Northstar policy determines the actual vendor results. See the
 
 See the [timed session plan](session-plan.md) for the full run of show and drop-if-behind rules.
 
+## How the packet fits together
+
+```mermaid
+flowchart LR
+    S["Session thesis and curriculum"] --> W["Attendee workbook"]
+    S --> D["Live and prepared demo"]
+    W --> A["Audience workflow map"]
+    D --> A
+    D --> E["Evidence and acceptance scenarios"]
+    A --> N["One reviewable next step"]
+    E --> N
+    F["Facilitator notes and fallback plan"] --> S
+    F --> D
+```
+
 ## Start here
 
 - Attending: [attendee links](attendee-links.md) and

--- a/event-specific/2026-08-19-houston-business-analysts-codex/ai-ready-workflow-worked-example.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/ai-ready-workflow-worked-example.md
@@ -22,6 +22,20 @@ Generate a draft vendor-review packet from fictional source files, then let a
 human verify its classification, evidence, missing information, and next owner.
 No approval, notification, or system update occurs.
 
+```mermaid
+flowchart LR
+    R["Requester submits vendor record"] --> V["Assistant validates and cites"]
+    V --> S{"Policy stop?"}
+    S -- Yes --> X["STOP / ESCALATE<br/>to Compliance"]
+    S -- No --> M{"Missing or unknown data?"}
+    M -- Yes --> C["CLARIFY<br/>through Procurement"]
+    M -- No --> P["PASS<br/>to required human reviews"]
+    X --> H["Named human owner decides"]
+    C --> H
+    P --> H
+    H --> A["Authorized employee may create record"]
+```
+
 ## What the example exposes
 
 - A complete record can pass to human review without being approved.

--- a/event-specific/2026-08-19-houston-business-analysts-codex/attendee-workbook.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/attendee-workbook.md
@@ -17,6 +17,15 @@ Then complete the five columns.
 See the [completed vendor-onboarding example](ai-ready-workflow-worked-example.md)
 before filling in your own canvas.
 
+```mermaid
+flowchart LR
+    P["People<br/>owners and decision rights"] --> W["Process<br/>trigger, flow, exceptions"]
+    W --> D["Data<br/>meaning, source, quality"]
+    D --> G["Guardrails<br/>limits, stops, approvals"]
+    G --> E["Proof<br/>expected outcomes and evidence"]
+    E -. "Learning changes the next version" .-> P
+```
+
 | People | Process | Data | Guardrails | Proof |
 |---|---|---|---|---|
 | Who owns the process? | What starts the work? | What data is required? | What must never happen? | What output is expected? |
@@ -112,6 +121,20 @@ Also record:
 ## Step 5: define the artifact stack
 
 Each artifact has a different job. Do not collapse them into one giant prompt.
+
+```mermaid
+flowchart LR
+    S["Source notes"] --> P["Process brief"]
+    S --> D["Data contract and glossary"]
+    P --> G["Standing guidance"]
+    D --> G
+    G --> O["SOP"]
+    P --> R["PRD"]
+    O --> K["Reusable skill"]
+    R --> K
+    K --> A["Acceptance checks"]
+    A --> E["Reviewable evidence"]
+```
 
 | Artifact | Write this down | Keep it authoritative when... |
 |---|---|---|

--- a/event-specific/2026-08-19-houston-business-analysts-codex/curriculum-map.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/curriculum-map.md
@@ -25,6 +25,18 @@ required.
 
 ## Learning progression
 
+```mermaid
+flowchart LR
+    P["Purpose<br/>Name the outcome"] --> C["Context<br/>Make the operating contract visible"]
+    C --> B["Capability bridge<br/>Connect BA and FDE practice"]
+    B --> F["Foundation<br/>People, process, data"]
+    F --> A["Artifacts<br/>Give each document one job"]
+    A --> H["Challenge<br/>Expose assumptions and conflicts"]
+    H --> O["Operation<br/>Turn context into repeatable work"]
+    O --> V["Assurance<br/>Pass, clarify, or stop"]
+    V --> N["Adoption<br/>Choose one reviewable next step"]
+```
+
 | Stage | Business analyst question | New operating concept | Evidence of learning |
 |---|---|---|---|
 | 1. Purpose | What outcome are we trying to reach? | Intent before acceleration | Attendee can state an outcome and proof, not just "use AI." |

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/README.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/README.md
@@ -6,6 +6,20 @@ a reviewable process packet and validates three prepared vendor cases.
 
 ## Folder map
 
+```mermaid
+flowchart LR
+    S["source/<br/>notes, policy, records"] --> P["prompts/<br/>guided analysis"]
+    F["framework-guidance.md<br/>business completeness lens"] --> P
+    P --> L["starter/<br/>clean live workspace"]
+    P --> W["workspace/<br/>completed fallback packet"]
+    W --> R["run-demo.mjs<br/>deterministic reviewer"]
+    R --> T["test/<br/>behavior checks"]
+    L --> V["verify-demo.mjs<br/>integrated packet check"]
+    W --> V
+    T --> V
+    C["corpora/<br/>additional BA practice"] -. "same source-to-decision pattern" .-> P
+```
+
 ```text
 demo/
 ├── source/                  # raw evidence and fictional records

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/corpora/README.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/corpora/README.md
@@ -17,6 +17,17 @@ Each corpus includes:
 - a run-ready analysis prompt; and
 - a facilitator key with expected findings and acceptance checks.
 
+```mermaid
+flowchart LR
+    N["Raw stakeholder notes"] --> A["Analyze claims and conflicts"]
+    P["Approved policy excerpts"] --> A
+    R["Three structured records"] --> A
+    A --> O["READY, CLARIFY, or ESCALATE result"]
+    O --> E["Acceptance scenarios and evidence"]
+    E --> F["Compare with facilitator key"]
+    F --> Q["Record disagreements for the named owner"]
+```
+
 ## How to use one
 
 1. Copy one corpus into a separate working folder.

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/framework-guidance.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/framework-guidance.md
@@ -42,6 +42,16 @@ improve the work.
 The framework method is **Understand → Document → Validate → Approve → Use →
 Improve**.
 
+```mermaid
+flowchart LR
+    U["Understand<br/>sources, people, current state"] --> D["Document<br/>meaning, rules, procedure"]
+    D --> V["Validate<br/>normal, exception, stop"]
+    V --> A["Approve<br/>accountable human authority"]
+    A --> O["Use<br/>perform and retain evidence"]
+    O --> I["Improve<br/>review outcomes and exceptions"]
+    I -. "approved change" .-> U
+```
+
 - The live session demonstrates Understand, Document, and Validate.
 - The fictional assistant never performs Approve.
 - Use would require the organization's normal governance and systems.

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/README.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/README.md
@@ -6,6 +6,21 @@ into reviewable responsibilities.
 
 ## Artifact map
 
+```mermaid
+flowchart LR
+    S["Approved policy and source records"] --> P["Process brief"]
+    S --> D["Data contract and glossary"]
+    P --> G["AGENTS.md<br/>standing guidance"]
+    D --> G
+    G --> O["SOP<br/>repeatable procedure"]
+    P --> R["PRD<br/>problem, scope, success"]
+    O --> K["Skill<br/>focused reusable workflow"]
+    R --> K
+    K --> A["Acceptance scenarios"]
+    A --> V["Verification report"]
+    M["Memory<br/>helpful recall only"] -. "context, never policy" .-> G
+```
+
 | File | Business question |
 |---|---|
 | [`AGENTS.md`](AGENTS.md) | What standing rules must Codex follow here? |

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/acceptance-scenarios.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/acceptance-scenarios.md
@@ -3,6 +3,16 @@
 These scenarios are defined before live execution. They test business behavior,
 not writing style.
 
+```mermaid
+flowchart LR
+    A["V-001<br/>Complete and clear"] --> P["PASS<br/>Procurement + Finance"]
+    B["V-002<br/>Security inputs unknown"] --> C["CLARIFY<br/>Procurement + Finance + Security"]
+    D["V-003<br/>Possible sanctions match + rush"] --> S["STOP / ESCALATE<br/>Compliance"]
+    P --> H["Human review remains required"]
+    C --> H
+    S --> H
+```
+
 ## Scenario A: complete packet
 
 - Record: V-001 / REQ-2601

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/process-brief.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/process-brief.md
@@ -54,6 +54,21 @@ The assistant may standardize steps 2-5 into a draft review packet. It may:
 
 It may not perform steps 6-7, resolve domain flags, or contact anyone.
 
+```mermaid
+flowchart LR
+    subgraph assistant["Assistant-supported work"]
+        I["Submitted request"] --> V["Validate record"]
+        V --> R["Identify review lanes"]
+        R --> E["Cite rules and prepare questions"]
+        E --> P["Draft review packet"]
+    end
+    P --> H["Procurement and domain reviewers"]
+    subgraph human["Human-only authority"]
+        H --> D["Finance, Security, Legal, or Compliance decision"]
+        D --> C["Authorized ProcureFlow record creation"]
+    end
+```
+
 ## Decision model
 
 Apply outcomes in this order:

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/vendor-onboarding-assistant-prd.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/vendor-onboarding-assistant-prd.md
@@ -17,6 +17,19 @@ documents, which makes outcomes difficult to trace.
 Create a draft-only assistant that converts one fictional intake record into a
 consistent, source-cited review packet for the correct human owners.
 
+```mermaid
+flowchart LR
+    S["Policy, record, and data definitions"] --> A["Review assistant"]
+    A --> V["Validate fields"]
+    A --> R["Route human review lanes"]
+    A --> E["Preserve citations and questions"]
+    V --> P["Draft packet"]
+    R --> P
+    E --> P
+    P --> H["Accountable human reviewers"]
+    A -. "No approval, messaging, or system mutation" .-> X["External parties and ProcureFlow"]
+```
+
 ## Users
 
 - Procurement coordinator preparing the packet

--- a/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/vendor-onboarding-sop.md
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/demo/workspace/vendor-onboarding-sop.md
@@ -27,6 +27,23 @@ A review packet containing:
 
 ## Procedure
 
+```mermaid
+flowchart TD
+    A["Confirm draft-only authority"] --> R["Select exactly one vendor record"]
+    R --> S{"Sanctions stop?"}
+    S -- Yes --> X["STOP / ESCALATE to Compliance"]
+    S -- No --> V["Validate required fields"]
+    V --> L["Identify required review lanes"]
+    L --> D{"Duplicate unresolved?"}
+    D -- Yes --> C["CLARIFY to Procurement"]
+    D -- No --> M{"Required information complete?"}
+    M -- No --> C
+    M -- Yes --> P["PASS to human review"]
+    X --> E["Produce cited evidence packet"]
+    C --> E
+    P --> E
+```
+
 ### 1. Establish the authority boundary
 
 Read P-01 and confirm the work is draft-only. If asked to create, approve,


### PR DESCRIPTION
## Summary

- add 13 Mermaid diagrams across 12 HOUBAs event documents
- visualize the curriculum, artifact stack, framework lifecycle, demo architecture, authority boundaries, decision paths, validation scenarios, and practice-corpus flow
- keep the HTML slides and PDF unchanged

## Verification

- checked Mermaid fence and flowchart declarations
- ran `git diff --check`
- preserved existing content and links

Closes #136