### PR TITLE
Release AI Dev Days v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+No changes yet.
+
+## 1.1.0 - 2026-08-22
+
+- Added the Houston Business Analysts HTML deck, curriculum map, 65-minute
+  speaker notes, organizer assets, and deck verification, then published the
+  approved 27-page high-resolution PDF.
 - Added a sourced two-slide BA and Forward Deployed Engineering capability
   bridge to the HOUBAs deck, with corrected indexed-posting context and explicit
   technical-ownership boundaries, then published the complete 27-page PDF from
@@ -21,6 +28,14 @@
 - Completed the HOUBAs executable demonstration with staged Codex workspaces,
   run-ready prompts, framework guidance, a deterministic vendor-review CLI,
   and focused behavior tests.
+- Added Mermaid diagrams to the HOUBAs PRD, curriculum map, build plan, session
+  plan, worked example, and demo guide to make the delivery model easier to
+  teach and review.
+- Updated Beaver Badges development dependencies to PostCSS 8.5.26,
+  `@types/react-dom` 19.2.4, and Vite 8.2.1 after isolated install, audit,
+  typecheck, build, visual-smoke, and full repository validation.
+- Corrected the HOUBAs HTML deck's initial slide counter to match its 27-slide
+  source and generated PDF.
 
 ## 1.0.0 - 2026-08-03
 
@@ -56,9 +71,7 @@
 - Added repository and event-path migration guidance.
 - Added the August 19, 2026 Houston Business Analysts first-pass event packet,
   attendee workbook, prompts, runbooks, and verified fictional vendor-onboarding
-  demo workspace; added the BA-focused HTML deck, curriculum map, speaker notes,
-  organizer assets, and deck verification while deferring the PDF until final
-  slide approval.
+  demo workspace; presentation slides remain deferred.
 - Added the June 1, 2026 GitHub Build creator demo packet with deck, prompt pack, speaker notes, fallback plan, and Discord QR asset.
 - Added repository audit, external link checking, and a GitHub Actions quality workflow.
 - Added Dependabot coverage for Beaver Badges app dependencies and GitHub Actions.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,6 +1,6 @@
 # AI Dev Days Charter
 
-**Status:** AI Dev Days version 1.0.0<br>
+**Status:** AI Dev Days version 1.1.0<br>
 **Founding steward:** Brad Groux<br>
 **Prepared:** 2026-07-30<br>
 **Effective date:** 2026-08-03

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 repository-code: "https://github.com/BradGroux/ai-dev-days"
 url: "https://github.com/BradGroux/ai-dev-days"
 license: MIT
-version: 1.0.0
-date-released: 2026-08-03
+version: 1.1.0
+date-released: 2026-08-22
 abstract: >-
   An independent learning community and event repository that adopts Open
   Framework Commons v1.0.0, with reusable curriculum, events, labs, tool

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # SOP: Contributing to AI Dev Days
 
-**Status:** Version 1.0.0<br>
+**Status:** Version 1.1.0<br>
 **Accountable owner:** Founding steward or future governing body<br>
 **Process manager:** Program maintainer<br>
 **Prepared:** 2026-07-30<br>

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # AI Dev Days Governance
 
-**Status:** AI Dev Days version 1.0.0<br>
+**Status:** AI Dev Days version 1.1.0<br>
 **Founding steward:** Brad Groux<br>
 **Prepared:** 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Start with [`START-HERE.md`](START-HERE.md) if you are not sure which file you n
 
 ## Featured Event Packets
 
-### Upcoming: Houston Business Analysts - August 19, 2026
+### Featured packet: Houston Business Analysts - August 19, 2026
 
 Interactive session for business analysis practitioners and business-technology
 partners on turning requirements, process knowledge, and data definitions into

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -2,6 +2,9 @@
 
 This folder contains human-readable release notes and known limitations.
 
+- [AI Dev Days 1.1.0](v1.1.0.md)
+- [AI Dev Days 1.0.0](v1.0.0.md)
+
 Repository integration does not make a release official. Follow
 [`docs/release-process.md`](../release-process.md) and obtain explicit release
 approval before creating a tag or GitHub release.

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -1,0 +1,90 @@
+# AI Dev Days 1.1.0
+
+**Status:** Approved release<br>
+**Commons adoption:** Open Framework Commons v1.0.0 at `a0f0d384e9010a65d1a21a324b4c912433d5e031`<br>
+**Teaching compatibility:** AI-Native Operating Framework 1.0.0 when selected<br>
+**Prepared:** 2026-08-22<br>
+**Approved:** 2026-08-22<br>
+**Released:** 2026-08-22<br>
+**Tag:** `v1.1.0`<br>
+**Superseded public version:** `v1.0.0`<br>
+**Responsible steward:** Brad Groux
+
+## Summary
+
+AI Dev Days 1.1.0 turns the August 19 Houston Business Analysts packet into a
+complete, reusable workshop package. The release adds a source-backed
+business-analysis and Forward Deployed Engineering capability bridge, a
+27-slide HTML and PDF deck, two practice corpora, an executable fictional
+vendor-review demonstration, facilitator material, and visual teaching maps.
+
+This is a backward-compatible program and content release. AI Dev Days remains
+independent, retains its Open Framework Commons v1.0.0 pin, and keeps the
+AI-Native Operating Framework optional and product-local when selected for
+teaching.
+
+## Added
+
+- A 27-slide Houston Business Analysts deck with dark and light themes,
+  direct-addressable slides, keyboard navigation, presenter controls, safe
+  external links, and a high-resolution PDF assembled from one 1920 by 1080
+  dark-theme image per slide.
+- A sourced market signal that labels Indeed data as an indexed posting series,
+  not raw job counts, and a capability bridge that uses IIBA and OpenAI sources
+  without equating business analysts and Forward Deployed Engineers.
+- A staged, executable vendor-onboarding demonstration with fictional data,
+  source notes, prompts, workspace guidance, deterministic review logic,
+  acceptance scenarios, and focused tests.
+- Practice corpora for change-request impact analysis and stakeholder-intake
+  prioritization, including source material, governing constraints,
+  facilitator keys, and expected review behavior.
+- Mermaid views of the event learning sequence, capability progression,
+  artifact flow, verification loop, and executable demo.
+
+## Changed
+
+- Refined the event's presenter, host, community, resource, and closing slides
+  while preserving organizer-required placement and a 65-minute core session.
+- Updated speaker notes, curriculum, session planning, attendee material,
+  facilitator runbooks, fallback guidance, and release validation to match the
+  final 27-slide package.
+- Updated Beaver Badges development dependencies to PostCSS 8.5.26,
+  `@types/react-dom` 19.2.4, and Vite 8.2.1.
+
+## Fixed
+
+- Corrected the HTML deck's static fallback counter from 25 to 27 slides. The
+  runtime counter was already correct, but the source now agrees before
+  JavaScript initializes.
+
+## Verification
+
+- The repository publication scan, structure and local-link audit, external
+  link check, event metadata validation, YAML parsing, and diff checks pass.
+- The HOUBAs verifier confirms 27 sequential HTML slides, 27 PDF pages, one
+  1920 by 1080 image per page, safe HTTPS annotations, and HTML/PDF link parity.
+- Slides 9 and 10 render at 1920 by 1080 in dark and light themes without
+  browser errors or visible overflow.
+- Beaver Badges installs reproducibly with zero audit vulnerabilities, passes
+  TypeScript checking, builds with Vite 8.2.1, and passes visual smoke testing.
+- Dependency pull requests #129, #130, and #131 passed independent standards
+  and specification review plus the hosted Quality workflow before merge.
+
+## Known Limitations
+
+- The event packet is complete, but this release does not claim that the August
+  19 event occurred or that post-event outcomes were collected. The event
+  metadata and post-event review remain pending accountable disposition.
+- Historical event packets retain point-in-time tool and event assumptions.
+- Learner-outcome, accessibility, and domain-review depth still varies across
+  historical events and must not be inferred from repository publication.
+- External sites may rate-limit or block automated checks. The release gate
+  treats inaccessible non-terminal responses as warnings while failing known
+  missing resources.
+
+## Publication Record
+
+The founding steward authorized the release on 2026-08-22. The annotated
+`v1.1.0` tag and GitHub release are created only from the verified merged
+default-branch tree. The public release records the exact release commit and
+links this repository-owned release note.

--- a/docs/research-and-education-method.md
+++ b/docs/research-and-education-method.md
@@ -1,6 +1,6 @@
 # AI Dev Days Research and Education Method
 
-**Status:** Version 1.0.0<br>
+**Status:** Version 1.1.0<br>
 **Owner:** AI Dev Days founding steward or delegated program maintainer<br>
 **Prepared:** 2026-07-30<br>
 **Commons adoption:** [Open Framework Commons v1.0.0](https://github.com/BradGroux/open-framework-commons/releases/tag/v1.0.0) at `a0f0d384e9010a65d1a21a324b4c912433d5e031`

--- a/event-specific/2026-08-19-houston-business-analysts-codex/slides.html
+++ b/event-specific/2026-08-19-houston-business-analysts-codex/slides.html
@@ -963,7 +963,7 @@ Prepare a review packet.
     </div>
   </section>
 
-  <div class="footer"><span>From Requirements to Reliable AI · Houston Business Analysts</span><span id="counter">1 / 25</span></div>
+  <div class="footer"><span>From Requirements to Reliable AI · Houston Business Analysts</span><span id="counter">1 / 27</span></div>
   <div class="nav">
     <button type="button" id="prev" aria-label="Previous slide" title="Previous slide"><svg viewBox="0 0 24 24"><path d="m15 18-6-6 6-6"/></svg></button>
     <button type="button" id="next" aria-label="Next slide" title="Next slide"><svg viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></button>

--- a/scripts/audit-repo.mjs
+++ b/scripts/audit-repo.mjs
@@ -29,6 +29,7 @@ const requiredFiles = [
   'docs/research-and-education-method.md',
   'docs/release-process.md',
   'docs/releases/v1.0.0.md',
+  'docs/releases/v1.1.0.md',
   'research/README.md',
   'research/source-note-template.md',
   'research/digital-meld-operating-research.md',


### PR DESCRIPTION
## Summary

- publish the accumulated Houston Business Analysts workshop package as AI Dev Days v1.1.0
- fix the audited stale 25-slide fallback counter while preserving verified 27-slide HTML/PDF parity
- record the v1.1.0 changelog, citation metadata, governing document status, release navigation, and full release notes
- preserve the published v1.0.0 changelog as point-in-time history

## Open-submission audit

- #130 PostCSS 8.5.26: accepted and merged after isolated and hosted validation
- #129 React DOM types 19.2.4: accepted and merged after isolated and hosted validation
- #131 Vite 8.2.1: accepted and merged after isolated and hosted validation
- #134 BA/FDE bridge: all substantive acceptance criteria pass; this PR resolves the remaining stale source counter

## Verification

- `./scripts/validate-release.sh`
- publication scan, repository audit, external-link check, YAML parsing, and diff checks
- HOUBAs demo/deck verifier, including 27 HTML slides, 27 PDF pages, 1920x1080 image parity, and safe-link parity
- 1920x1080 dark/light browser renders of slides 9 and 10 with no browser errors or visible overflow
- clean Beaver Badges install, zero audit vulnerabilities, TypeScript check, Vite 8.2.1 build, and visual smoke
- independent standards and specification review of the release diff

## Risk and limitations

- The August 19 event is still marked `planned`; no accountable post-event record proves delivery or learner outcomes. The release notes preserve that limitation.
- External sites can rate-limit automated checks. Known missing resources remain hard failures; blocked or transient non-terminal responses are warnings.
- The annotated tag and GitHub release remain blocked on the repository's explicit post-candidate approval gate.

## Release authority gate

Do not merge, tag, or publish until the founding steward reviews the exact candidate commit, final audit, release notes, known limitations, and proposed publication actions and explicitly approves them.

Closes #134
Closes #138
